### PR TITLE
Add SPIFFEPrincipalExtractor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * [Resource Sharing] Adds migrate API to move resource-sharing info to security plugin ([#5389](https://github.com/opensearch-project/security/pull/5389))
 * Introduces support for the Argon2 Password Hashing Algorithm ([#5441] (https://github.com/opensearch-project/security/pull/5441))
 * Introduced permission validation support using query parameter without executing the request ([#5496](https://github.com/opensearch-project/security/pull/5496))
+* Introduced SPIFFE X.509 SVID support via SPIFFEPrincipalExtractor ([#5521](https://github.com/opensearch-project/security/pull/5521))
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * [Resource Sharing] Adds migrate API to move resource-sharing info to security plugin ([#5389](https://github.com/opensearch-project/security/pull/5389))
 * Introduces support for the Argon2 Password Hashing Algorithm ([#5441] (https://github.com/opensearch-project/security/pull/5441))
 * Introduced permission validation support using query parameter without executing the request ([#5496](https://github.com/opensearch-project/security/pull/5496))
+* Add support for configuring auxiliary transports for SSL only ([#5375] (https://github.com/opensearch-project/security/pull/5375))
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bump `org.xerial.snappy:snappy-java` from 1.1.10.7 to 1.1.10.8 ([#5495](https://github.com/opensearch-project/security/pull/5495))
 - Bump `org.apache.commons:commons-text` from 1.13.1 to 1.14.0 ([#5511](https://github.com/opensearch-project/security/pull/5511))
 - Bump `org.springframework.kafka:spring-kafka-test` from 4.0.0-M2 to 4.0.0-M3 ([#5514](https://github.com/opensearch-project/security/pull/5514))
+- Bumps opensearch-protobufs plugin version to 0.6.0 ([#5529](https://github.com/opensearch-project/security/pull/5529))
 
 ### Documentation
 

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ buildscript {
         guava_version = '33.4.8-jre'
         jaxb_version = '2.3.9'
         spring_version = '6.2.9'
+        protobuf_plugin_version = '0.6.0'
 
         if (buildVersionQualifier) {
             opensearch_build += "-${buildVersionQualifier}"
@@ -533,7 +534,7 @@ allprojects {
         integrationTestImplementation("org.opensearch.plugin:reindex-client:${opensearch_version}"){
             exclude(group: 'org.slf4j', module: 'slf4j-api')
         }
-        integrationTestImplementation "org.opensearch:protobufs:0.3.0"
+        integrationTestImplementation "org.opensearch:protobufs:${protobuf_plugin_version}"
         integrationTestImplementation "io.grpc:grpc-stub:${versions.grpc}"
         integrationTestImplementation "io.grpc:grpc-netty-shaded:${versions.grpc}"
         integrationTestImplementation "org.opensearch.plugin:transport-grpc:${opensearch_version}"

--- a/build.gradle
+++ b/build.gradle
@@ -491,6 +491,9 @@ configurations {
             force "net.bytebuddy:byte-buddy:1.17.6"
             force "org.ow2.asm:asm:9.8"
             force "com.google.j2objc:j2objc-annotations:3.0.0"
+
+            // For org.opensearch.plugin:transport-grpc
+            force "com.google.guava:failureaccess:1.0.2"
         }
     }
 
@@ -530,6 +533,10 @@ allprojects {
         integrationTestImplementation("org.opensearch.plugin:reindex-client:${opensearch_version}"){
             exclude(group: 'org.slf4j', module: 'slf4j-api')
         }
+        integrationTestImplementation "org.opensearch:protobufs:0.3.0"
+        integrationTestImplementation "io.grpc:grpc-stub:${versions.grpc}"
+        integrationTestImplementation "io.grpc:grpc-netty-shaded:${versions.grpc}"
+        integrationTestImplementation "org.opensearch.plugin:transport-grpc:${opensearch_version}"
         integrationTestImplementation "org.opensearch.plugin:percolator-client:${opensearch_version}"
         integrationTestImplementation 'commons-io:commons-io:2.20.0'
         integrationTestImplementation "org.apache.logging.log4j:log4j-core:${versions.log4j}"
@@ -567,7 +574,6 @@ allprojects {
         integrationTestImplementation 'org.slf4j:slf4j-api:2.0.12'
         integrationTestImplementation 'com.selectivem.collections:special-collections-complete:1.4.0'
         integrationTestImplementation "org.opensearch.plugin:lang-painless:${opensearch_version}"
-
     }
 }
 

--- a/bwc-test/build.gradle
+++ b/bwc-test/build.gradle
@@ -147,7 +147,7 @@ def String extractVersion(versionStr) {
                 node.setting("plugins.security.ssl.http.pemtrustedcas_filepath", "root-ca.pem")
                 node.setting("plugins.security.allow_unsafe_democertificates", "true")
                 node.setting("plugins.security.allow_default_init_securityindex", "true")
-                node.setting("plugins.security.authcz.admin_dn", "CN=kirk,OU=client,O=client,L=test,C=de")
+                node.setting("plugins.security.authcz.admin_dn", "\n - CN=kirk,OU=client,O=client,L=test,C=de")
                 node.setting("plugins.security.audit.type", "internal_opensearch")
                 node.setting("plugins.security.enable_snapshot_restore_privilege", "true")
                 node.setting("plugins.security.check_snapshot_restore_write_privileges", "true")

--- a/bwc-test/src/test/java/org/opensearch/security/bwc/SecurityBackwardsCompatibilityIT.java
+++ b/bwc-test/src/test/java/org/opensearch/security/bwc/SecurityBackwardsCompatibilityIT.java
@@ -8,10 +8,14 @@
 package org.opensearch.security.bwc;
 
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -42,10 +46,12 @@ import org.opensearch.client.ResponseException;
 import org.opensearch.client.RestClient;
 import org.opensearch.client.RestClientBuilder;
 import org.opensearch.common.Randomness;
+import org.opensearch.common.io.PathUtils;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.util.io.IOUtils;
 import org.opensearch.common.xcontent.support.XContentMapValues;
+import org.opensearch.commons.rest.SecureRestClientBuilder;
 import org.opensearch.security.bwc.helper.RestHelper;
 import org.opensearch.test.rest.OpenSearchRestTestCase;
 
@@ -119,6 +125,19 @@ public class SecurityBackwardsCompatibilityIT extends OpenSearchRestTestCase {
             .build();
     }
 
+    @Override
+    protected Settings restAdminSettings() {
+        return Settings.builder()
+            .put("http.port", 9200)
+            .put("plugins.security.ssl.http.enabled", true)
+            // this is incorrect on common-utils side. It should be using `pemtrustedcas_filepath`
+            .put("plugins.security.ssl.http.pemcert_filepath", "sample.pem")
+            .put("plugins.security.ssl.http.keystore_filepath", "test-kirk.jks")
+            .put("plugins.security.ssl.http.keystore_password", "changeit")
+            .put("plugins.security.ssl.http.keystore_keypassword", "changeit")
+            .build();
+    }
+
     protected RestClient buildClient(Settings settings, HttpHost[] hosts, String username, String password) {
         RestClientBuilder builder = RestClient.builder(hosts);
         configureHttpsClient(builder, settings, username, password);
@@ -128,7 +147,18 @@ public class SecurityBackwardsCompatibilityIT extends OpenSearchRestTestCase {
     }
 
     @Override
-    protected RestClient buildClient(Settings settings, HttpHost[] hosts) {
+    protected RestClient buildClient(Settings settings, HttpHost[] hosts) throws IOException {
+        String keystore = settings.get("plugins.security.ssl.http.keystore_filepath");
+        if (Objects.nonNull(keystore)) {
+            URI uri = null;
+            try {
+                uri = this.getClass().getClassLoader().getResource("security/test-kirk.jks").toURI();
+            } catch (URISyntaxException e) {
+                throw new RuntimeException(e);
+            }
+            Path configPath = PathUtils.get(uri).getParent().toAbsolutePath();
+            return new SecureRestClientBuilder(settings, configPath, hosts).build();
+        }
         String username = Optional.ofNullable(System.getProperty("tests.opensearch.username"))
             .orElseThrow(() -> new RuntimeException("user name is missing"));
         String password = Optional.ofNullable(System.getProperty("tests.opensearch.password"))
@@ -166,6 +196,65 @@ public class SecurityBackwardsCompatibilityIT extends OpenSearchRestTestCase {
                 throw new RuntimeException(e);
             }
         });
+    }
+
+    /**
+     * Test /certificates endpoint.
+     * Validate certificate info for correctness and check for errors.
+     */
+    public void testSslCertsInfoEndpoint() throws IOException {
+        List<String> expectCertificates = List.of("http", "transport", "transport_client");
+        List<Response> resp = RestHelper.requestAgainstAllNodes(adminClient(), "GET", "_plugins/_security/api/certificates", null);
+        resp.forEach(response -> {
+            assertEquals("SSL certs info endpoint should return 200", 200, response.getStatusLine().getStatusCode());
+            Map<String, Object> responseMap;
+            try {
+                responseMap = responseAsMap(response);
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to parse certs info response", e);
+            }
+            @SuppressWarnings("unchecked")
+            Map<String, Object> nodeFailureMap = (Map<String, Object>) responseMap.get("_nodes");
+            assertEquals(3, nodeFailureMap.get("total"));
+            assertEquals(3, nodeFailureMap.get("successful"));
+            assertEquals(0, nodeFailureMap.get("failed"));
+            @SuppressWarnings("unchecked")
+            Map<String, Object> nodesMap = (Map<String, Object>) responseMap.get("nodes");
+            for (String nodeKey : nodesMap.keySet()) {
+                @SuppressWarnings("unchecked")
+                Map<String, Object> nodeInfo = (Map<String, Object>) nodesMap.get(nodeKey);
+                @SuppressWarnings("unchecked")
+                Map<String, Object> nodeCerts = (Map<String, Object>) nodeInfo.get("certificates");
+                for (String expectCertKey : expectCertificates) {
+                    assertTrue(nodeCerts.containsKey(expectCertKey));
+                    @SuppressWarnings("unchecked")
+                    List<Map<String, Object>> certList = (List<Map<String, Object>>) nodeCerts.get(expectCertKey);
+                    for (Map<String, Object> singleCert : certList) {
+                        verifyCertificateInfo(singleCert);
+                    }
+                }
+            }
+        });
+    }
+
+    /**
+     * Validate the structure of certificates info response items.
+     */
+    private void verifyCertificateInfo(Map<String, Object> certInfo) {
+        assertThat("Certificate should have subject_dn", certInfo, hasKey("subject_dn"));
+        assertThat("Certificate should have issuer_dn", certInfo, hasKey("issuer_dn"));
+        assertThat("Certificate should have not_before", certInfo, hasKey("not_before"));
+        assertThat("Certificate should have not_after", certInfo, hasKey("not_after"));
+        Object subjectDn = certInfo.get("subject_dn");
+        if (subjectDn != null) {
+            assertTrue("subject_dn should be a string", subjectDn instanceof String);
+            assertFalse("subject_dn should not be empty", ((String) subjectDn).isEmpty());
+        }
+        Object issuerDn = certInfo.get("issuer_dn");
+        if (issuerDn != null) {
+            assertTrue("issuer_dn should be a string", issuerDn instanceof String);
+            assertFalse("issuer_dn should not be empty", ((String) issuerDn).isEmpty());
+        }
     }
 
     public void testWhoAmI() throws Exception {

--- a/sample-resource-plugin/build.gradle
+++ b/sample-resource-plugin/build.gradle
@@ -56,6 +56,13 @@ configurations.all {
         force 'org.hamcrest:hamcrest:2.2'
         force 'org.mockito:mockito-core:5.18.0'
         force 'org.slf4j:slf4j-api:1.7.36'
+
+        // Duplicate dependencies with conflicting versions from org.opensearch.plugin:transport-grpc
+        // Force versions present in security plugin
+        force "com.google.errorprone:error_prone_annotations:2.36.0"
+        force "com.google.protobuf:protobuf-java:${versions.protobuf}"
+        force "com.google.guava:guava:${guava_version}"
+        force "com.google.guava:failureaccess:1.0.3"
     }
 }
 

--- a/src/integrationTest/java/org/opensearch/security/ParentChildRelationTests.java
+++ b/src/integrationTest/java/org/opensearch/security/ParentChildRelationTests.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+package org.opensearch.security;
+
+import java.util.List;
+import java.util.Map;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.indices.TermsLookup;
+import org.opensearch.test.framework.TestSecurityConfig.AuthcDomain;
+import org.opensearch.test.framework.TestSecurityConfig.Role;
+import org.opensearch.test.framework.TestSecurityConfig.User;
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.TestRestClient;
+import org.opensearch.test.framework.cluster.TestRestClient.HttpResponse;
+import org.opensearch.transport.client.Client;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
+import static org.opensearch.test.framework.TestSecurityConfig.Role.ALL_ACCESS;
+import static org.opensearch.test.framework.matcher.RestMatchers.isInternalServerError;
+import static org.opensearch.test.framework.matcher.RestMatchers.isOk;
+
+@RunWith(com.carrotsearch.randomizedtesting.RandomizedRunner.class)
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class ParentChildRelationTests {
+    public static final String INDEX_NAME = "dlstest";
+    public static final String TERM_LOOKUP_INDEX_NAME = "term_lookup_index";
+    public static final String TERMS_DOC_ID = "terms_2_2000";
+    public static final String TERM_PATH = "terms_to_search";
+
+    private static final User ADMIN_USER = new User("admin").roles(ALL_ACCESS);
+    private static final User DLS_TEST_USER = new User("dls_test_user").roles(
+        new Role("dls_test_role") //
+            .clusterPermissions("*") //
+            .indexPermissions("read") //
+            .dls(QueryBuilders.termQuery("dls", "2")) //
+            .on(INDEX_NAME)
+    );
+    private static final User DLS_TLQ_TEST_USER = new User("dls_tlq_test_user").roles(
+        new Role("dls_tlq_test_role").clusterPermissions("*") //
+            .indexPermissions("read") //
+            .dls(QueryBuilders.termsLookupQuery("dsl", new TermsLookup(TERM_LOOKUP_INDEX_NAME, TERMS_DOC_ID, TERM_PATH))) //
+            .on(INDEX_NAME)
+    );
+
+    public static final int BASIC_AUTH_DOMAIN_ORDER = 0;
+    public final static AuthcDomain AUTHC_HTTPBASIC_INTERNAL = new AuthcDomain("basic", BASIC_AUTH_DOMAIN_ORDER) //
+        .httpAuthenticatorWithChallenge("basic") //
+        .backend("internal");
+
+    @ClassRule
+    public static final LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE) //
+        .anonymousAuth(false) //
+        .authc(AUTHC_HTTPBASIC_INTERNAL) //
+        .users(ADMIN_USER, DLS_TEST_USER, DLS_TLQ_TEST_USER) //
+        .build();
+
+    @BeforeClass
+    public static void beforeClass() {
+        Map<String, Object> indexMapping = Map.of(
+            "properties",
+            Map.of(
+                "dls",
+                Map.of("type", "keyword"),
+                "entityStatements",
+                Map.of("type", "join", "relations", Map.of("entity", "statements"))
+            )
+        );
+        try (TestRestClient client = cluster.getRestClient(ADMIN_USER)) {
+            // first create an index
+            HttpResponse response = client.put(INDEX_NAME);
+            assertThat(response, isOk());
+            // this will fail if the index does not exist
+            IndexOperationsHelper.createMapping(cluster, INDEX_NAME, indexMapping);
+        }
+        try (Client client = cluster.getInternalNodeClient()) {
+            Map<String, Object> document = Map.of("dls", "1", "entityStatements", "entity");
+            client.prepareIndex(INDEX_NAME).setId("1").setRefreshPolicy(IMMEDIATE).setSource(document).get();
+            document = Map.of("dls", "2", "entityStatements", "entity");
+            client.prepareIndex(INDEX_NAME).setId("2").setRefreshPolicy(IMMEDIATE).setSource(document).get();
+            document = Map.of("dls", "1", "entityStatements", Map.of("name", "statements", "parent", "1"));
+            client.prepareIndex(INDEX_NAME).setId("3").setRouting("1").setRefreshPolicy(IMMEDIATE).setSource(document).get();
+            document = Map.of("dls", "2", "entityStatements", Map.of("name", "statements", "parent", "1"));
+            client.prepareIndex(INDEX_NAME).setId("4").setRouting("1").setRefreshPolicy(IMMEDIATE).setSource(document).get();
+            document = Map.of("dls", "2", "entityStatements", Map.of("name", "statements", "parent", "2"));
+            client.prepareIndex(INDEX_NAME).setId("5").setRouting("1").setRefreshPolicy(IMMEDIATE).setSource(document).get();
+            document = Map.of("dls", "3", "entityStatements", Map.of("name", "statements", "parent", "2"));
+            client.prepareIndex(INDEX_NAME).setId("6").setRouting("1").setRefreshPolicy(IMMEDIATE).setSource(document).get();
+
+            // create a term lookup index
+            document = Map.of(TERM_PATH, List.of("2", "2000"));
+            client.prepareIndex(TERM_LOOKUP_INDEX_NAME).setId(TERMS_DOC_ID).setRefreshPolicy(IMMEDIATE).setSource(document).get();
+        }
+    }
+
+    @Test
+    public void dlsUserSearchAll() {
+        try (TestRestClient client = cluster.getRestClient(DLS_TEST_USER)) {
+            HttpResponse response = client.get(INDEX_NAME + "/_search?pretty");
+            assertThat(response, isOk());
+            JsonNode hits = response.bodyAsJsonNode().get("hits").get("hits");
+            assertThat(hits.size(), equalTo(3));
+            for (JsonNode hit : hits) {
+                String dlsValue = hit.get("_source").get("dls").asText();
+                assertThat(dlsValue, equalTo("2"));
+            }
+        }
+    }
+
+    @Test
+    public void hasParentWithDlsDisallowedParentQuery() {
+        try (TestRestClient client = cluster.getRestClient(DLS_TEST_USER)) {
+            HttpResponse response = client.postJson(INDEX_NAME + "/_search?pretty", """
+                {
+                    "query": {
+                        "has_parent": {
+                            "parent_type": "entity",
+                            "query": {
+                                "match": {
+                                    "dls": "1"
+                                }
+                            }
+                        }
+                    }
+                }
+                """);
+            assertThat(response, isOk());
+            JsonNode hits = response.bodyAsJsonNode().get("hits").get("hits");
+            assertThat(hits.size(), equalTo(0));
+        }
+    }
+
+    @Test
+    public void hasParentWithDlsAllowedParentQuery() {
+        try (TestRestClient client = cluster.getRestClient(DLS_TEST_USER)) {
+            HttpResponse response = client.postJson(INDEX_NAME + "/_search?pretty", """
+                {
+                    "query": {
+                        "has_parent": {
+                            "parent_type": "entity",
+                            "query": {
+                                "match": {
+                                    "dls": "2"
+                                }
+                            }
+                        }
+                    }
+                }
+                """);
+            assertThat(response, isOk());
+            JsonNode hits = response.bodyAsJsonNode().get("hits").get("hits");
+            assertThat(hits.size(), equalTo(1));
+            String documentId = response.bodyAsJsonNode().get("hits").get("hits").get(0).get("_id").asText();
+            assertThat(documentId, equalTo("5"));
+        }
+    }
+
+    @Test
+    public void hasChildWithDlsDisallowedChild() {
+        try (TestRestClient client = cluster.getRestClient(DLS_TEST_USER)) {
+            HttpResponse response = client.postJson(INDEX_NAME + "/_search?pretty", """
+                {
+                    "query": {
+                        "has_child": {
+                            "type": "statements",
+                            "query": {
+                                "match": {
+                                    "dls": "3"
+                                }
+                            }
+                        }
+                    }
+                }
+                """);
+            assertThat(response, isOk());
+            JsonNode hits = response.bodyAsJsonNode().get("hits").get("hits");
+            assertThat(hits.size(), equalTo(0));
+        }
+    }
+
+    @Test
+    public void hasChildWithDlsAllowedChild() {
+        try (TestRestClient client = cluster.getRestClient(DLS_TEST_USER)) {
+            HttpResponse response = client.postJson(INDEX_NAME + "/_search?pretty", """
+                {
+                    "query": {
+                        "has_child": {
+                            "type": "statements",
+                            "query": {
+                                "match": {
+                                    "dls": "2"
+                                }
+                            }
+                        }
+                    }
+                }
+                """);
+            assertThat(response, isOk());
+            JsonNode hits = response.bodyAsJsonNode().get("hits").get("hits");
+            assertThat(hits.size(), equalTo(1));
+            String documentId = response.bodyAsJsonNode().get("hits").get("hits").get(0).get("_id").asText();
+            assertThat(documentId, equalTo("2"));
+        }
+    }
+
+    @Test
+    public void hasParentWithTlqDls() {
+        try (TestRestClient client = cluster.getRestClient(DLS_TLQ_TEST_USER)) {
+            HttpResponse response = client.postJson(INDEX_NAME + "/_search?pretty", """
+                {
+                    "query": {
+                        "has_parent": {
+                            "parent_type": "entity",
+                            "query": {
+                                "match": {
+                                    "dls": "1"
+                                }
+                            }
+                        }
+                    }
+                }
+                """);
+            assertThat(response, isInternalServerError("/error/reason", "Unable to handle filter level DLS for parent or child queries"));
+        }
+    }
+}

--- a/src/integrationTest/java/org/opensearch/security/api/CertificatesRestApiIntegrationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/api/CertificatesRestApiIntegrationTest.java
@@ -14,9 +14,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
 
@@ -24,6 +22,7 @@ import com.carrotsearch.randomizedtesting.RandomizedContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.Test;
 
+import org.opensearch.common.CheckedConsumer;
 import org.opensearch.security.dlic.rest.api.Endpoint;
 import org.opensearch.security.ssl.config.CertType;
 import org.opensearch.test.framework.TestSecurityConfig;
@@ -37,12 +36,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.opensearch.security.OpenSearchSecurityPlugin.PLUGINS_PREFIX;
 import static org.opensearch.security.dlic.rest.api.RestApiAdminPrivilegesEvaluator.CERTS_INFO_ACTION;
 import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_ADMIN_ENABLED;
+import static junit.framework.TestCase.fail;
 
 public class CertificatesRestApiIntegrationTest extends AbstractApiIntegrationTest {
-
     final static String REST_API_ADMIN_SSL_INFO = "rest-api-admin-ssl-info";
-
     final static String REGULAR_USER = "regular_user";
+    final static String ROOT_CA = "Root CA";
 
     static {
         testSecurityConfig.roles(
@@ -89,13 +88,17 @@ public class CertificatesRestApiIntegrationTest extends AbstractApiIntegrationTe
 
     @Test
     public void availableForTlsAdmin() throws Exception {
-        withUser(ADMIN_USER_NAME, localCluster.getAdminCertificate(), this::verifySSLCertsInfo);
+        withUser(
+            ADMIN_USER_NAME,
+            localCluster.getAdminCertificate(),
+            verifySSLCertsInfo(List.of(CertType.HTTP, CertType.TRANSPORT, CertType.TRANSPORT_CLIENT))
+        );
     }
 
     @Test
     public void availableForRestAdmin() throws Exception {
-        withUser(REST_ADMIN_USER, this::verifySSLCertsInfo);
-        withUser(REST_API_ADMIN_SSL_INFO, this::verifySSLCertsInfo);
+        withUser(REST_ADMIN_USER, verifySSLCertsInfo(List.of(CertType.HTTP, CertType.TRANSPORT, CertType.TRANSPORT_CLIENT)));
+        withUser(REST_API_ADMIN_SSL_INFO, verifySSLCertsInfo(List.of(CertType.HTTP, CertType.TRANSPORT, CertType.TRANSPORT_CLIENT)));
     }
 
     @Test
@@ -107,72 +110,78 @@ public class CertificatesRestApiIntegrationTest extends AbstractApiIntegrationTe
         ok(() -> client.get(sslCertsPath() + "?timeout=0"));
     }
 
-    private void verifySSLCertsInfo(final TestRestClient client) throws Exception {
-        assertSSLCertsInfo(localCluster.nodes(), CertType.TYPES, ok(() -> client.get(sslCertsPath())));
-        if (localCluster.nodes().size() > 1) {
-            final var randomNodes = randomNodes();
-            final var nodeIds = randomNodes.stream().map(n -> n.esNode().getNodeEnvironment().nodeId()).collect(Collectors.joining(","));
-            assertSSLCertsInfo(randomNodes, CertType.TYPES, ok(() -> client.get(sslCertsPath(nodeIds))));
-        }
-        final var randomCertType = randomFrom(List.copyOf(CertType.TYPES));
-        assertSSLCertsInfo(
-            localCluster.nodes(),
-            Set.of(randomCertType),
-            ok(() -> client.get(String.format("%s?cert_type=%s", sslCertsPath(), randomCertType)))
-        );
-
+    private CheckedConsumer<TestRestClient, Exception> verifySSLCertsInfo(List<CertType> expectCerts) {
+        return testRestClient -> {
+            try {
+                assertSSLCertsInfo(localCluster.nodes(), expectCerts, ok(() -> testRestClient.get(sslCertsPath())));
+                if (localCluster.nodes().size() > 1) {
+                    final var randomNodes = randomNodes();
+                    final var nodeIds = randomNodes.stream()
+                        .map(n -> n.esNode().getNodeEnvironment().nodeId())
+                        .collect(Collectors.joining(","));
+                    assertSSLCertsInfo(randomNodes, expectCerts, ok(() -> testRestClient.get(sslCertsPath(nodeIds))));
+                }
+                final var randomCertType = randomFrom(expectCerts);
+                assertSSLCertsInfo(
+                    localCluster.nodes(),
+                    List.of(randomCertType),
+                    ok(() -> testRestClient.get(String.format("%s?cert_type=%s", sslCertsPath(), randomCertType)))
+                );
+            } catch (Exception e) {
+                fail("Verify SSLCerts info failed with exception: " + e.getMessage());
+            }
+        };
     }
 
     private void assertSSLCertsInfo(
         final List<LocalOpenSearchCluster.Node> expectedNode,
-        final Set<String> expectedCertTypes,
+        final List<CertType> expectedCertTypes,
         final TestRestClient.HttpResponse response
     ) {
         final var body = response.bodyAsJsonNode();
         final var prettyStringBody = body.toPrettyString();
-
         final var _nodes = body.get("_nodes");
         assertThat(prettyStringBody, _nodes.get("total").asInt(), is(expectedNode.size()));
         assertThat(prettyStringBody, _nodes.get("successful").asInt(), is(expectedNode.size()));
         assertThat(prettyStringBody, _nodes.get("failed").asInt(), is(0));
         assertThat(prettyStringBody, body.get("cluster_name").asText(), is(localCluster.getClusterName()));
-
         final var nodes = body.get("nodes");
-
         for (final var n : expectedNode) {
             final var esNode = n.esNode();
             final var node = nodes.get(esNode.getNodeEnvironment().nodeId());
             assertThat(prettyStringBody, node.get("name").asText(), is(n.getNodeName()));
             assertThat(prettyStringBody, node.has("certificates"));
             final var certificates = node.get("certificates");
-            if (expectedCertTypes.contains(CertType.HTTP.name().toUpperCase(Locale.ROOT))) {
-                final var httpCertificates = certificates.get(CertType.HTTP.name().toUpperCase(Locale.ROOT));
-                assertThat(prettyStringBody, httpCertificates.isArray());
-                assertThat(prettyStringBody, httpCertificates.size(), is(1));
-                verifyCertsJson(n.nodeNumber(), httpCertificates.get(0));
-            }
-            if (expectedCertTypes.contains(CertType.TRANSPORT_CLIENT.name().toUpperCase(Locale.ROOT))) {
-                final var transportCertificates = certificates.get(CertType.TRANSPORT.name().toUpperCase(Locale.ROOT));
+            /*
+            Expect each node transport configured with root and issued cert.
+            */
+            for (CertType expectCert : expectedCertTypes) {
+                final JsonNode transportCertificates = certificates.get(expectCert.id());
                 assertThat(prettyStringBody, transportCertificates.isArray());
-                assertThat(prettyStringBody, transportCertificates.size(), is(1));
+                assertThat(prettyStringBody, transportCertificates.size(), is(2));
                 verifyCertsJson(n.nodeNumber(), transportCertificates.get(0));
+                verifyCertsJson(n.nodeNumber(), transportCertificates.get(1));
             }
         }
-
     }
 
     private void verifyCertsJson(final int nodeNumber, final JsonNode jsonNode) {
+        if (jsonNode.get("subject_dn").asText().contains(ROOT_CA)) { // handle root cert
+            assertThat(jsonNode.toPrettyString(), jsonNode.get("subject_dn").asText(), is(TestCertificates.CA_SUBJECT));
+            assertThat(jsonNode.toPrettyString(), jsonNode.get("san").asText().isEmpty());
+        } else { // handle non-root
+            assertThat(
+                jsonNode.toPrettyString(),
+                jsonNode.get("subject_dn").asText(),
+                is(String.format(TestCertificates.NODE_SUBJECT_PATTERN, nodeNumber))
+            );
+            assertThat(
+                jsonNode.toPrettyString(),
+                jsonNode.get("san").asText(),
+                containsString(String.format("node-%s.example.com", nodeNumber))
+            );
+        }
         assertThat(jsonNode.toPrettyString(), jsonNode.get("issuer_dn").asText(), is(TestCertificates.CA_SUBJECT));
-        assertThat(
-            jsonNode.toPrettyString(),
-            jsonNode.get("subject_dn").asText(),
-            is(String.format(TestCertificates.NODE_SUBJECT_PATTERN, nodeNumber))
-        );
-        assertThat(
-            jsonNode.toPrettyString(),
-            jsonNode.get("san").asText(),
-            containsString(String.format("node-%s.example.com", nodeNumber))
-        );
         assertThat(jsonNode.toPrettyString(), jsonNode.has("not_before"));
         assertThat(jsonNode.toPrettyString(), jsonNode.has("not_after"));
     }
@@ -193,5 +202,4 @@ public class CertificatesRestApiIntegrationTest extends AbstractApiIntegrationTe
         Collections.shuffle(tempList, RandomizedContext.current().getRandom());
         return tempList.subList(0, size);
     }
-
 }

--- a/src/integrationTest/java/org/opensearch/security/grpc/GrpcClientAuthNoneTests.java
+++ b/src/integrationTest/java/org/opensearch/security/grpc/GrpcClientAuthNoneTests.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+package org.opensearch.security.grpc;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.opensearch.plugin.transport.grpc.GrpcPlugin;
+import org.opensearch.protobufs.BulkResponse;
+import org.opensearch.protobufs.SearchResponse;
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.LocalCluster;
+
+import io.grpc.ManagedChannel;
+import io.grpc.StatusRuntimeException;
+
+import static org.opensearch.security.grpc.GrpcHelpers.CLIENT_AUTH_NONE;
+import static org.opensearch.security.grpc.GrpcHelpers.SINGLE_NODE_SECURE_GRPC_TRANSPORT_SETTINGS;
+import static org.opensearch.security.grpc.GrpcHelpers.TEST_CERTIFICATES;
+import static org.opensearch.security.grpc.GrpcHelpers.getSecureGrpcEndpoint;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+
+@RunWith(com.carrotsearch.randomizedtesting.RandomizedRunner.class)
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class GrpcClientAuthNoneTests {
+    @ClassRule
+    public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
+        .plugin(GrpcPlugin.class)
+        .certificates(TEST_CERTIFICATES)
+        .nodeSettings(SINGLE_NODE_SECURE_GRPC_TRANSPORT_SETTINGS)
+        .loadConfigurationIntoIndex(false)
+        .sslOnly(true)
+        .nodeSettings(CLIENT_AUTH_NONE)
+        .build();
+
+    /**
+     * Closes the provided managed channel.
+     */
+    public static void assertBulkAndSearchTestIndex(ManagedChannel channel) {
+        int testDocs = (int) (Math.random() * 101);
+        String testIndex = UUID.randomUUID().toString().substring(0, 10);
+
+        BulkResponse bulkResp = GrpcHelpers.doBulk(channel, testIndex, testDocs);
+        assertNotNull(bulkResp);
+        assertFalse(bulkResp.hasBulkErrorResponse());
+        assertEquals(testDocs, bulkResp.getBulkResponseBody().getItemsCount());
+
+        SearchResponse searchResp = GrpcHelpers.doMatchAll(channel, testIndex, 10);
+        assertNotNull(searchResp);
+        assertEquals(SearchResponse.ResponseCase.RESPONSE_BODY.getNumber(), searchResp.getResponseCase().getNumber());
+        assertEquals(testDocs, searchResp.getResponseBody().getHits().getTotal().getTotalHits().getValue());
+
+        channel.shutdown();
+    }
+
+    @Test
+    public void testPlaintextChannel() {
+        ManagedChannel channel = GrpcHelpers.plaintextChannel(getSecureGrpcEndpoint(cluster));
+        StatusRuntimeException exception = assertThrows(StatusRuntimeException.class, () -> { assertBulkAndSearchTestIndex(channel); });
+        assertEquals("UNAVAILABLE: Network closed for unknown reason", exception.getMessage());
+        channel.shutdown();
+    }
+
+    @Test
+    public void testBulkAndSearchInsecureChannel() {
+        assertBulkAndSearchTestIndex(GrpcHelpers.insecureChannel(getSecureGrpcEndpoint(cluster)));
+    }
+
+    @Test
+    public void testBulkAndSearchSecureChannel() throws IOException {
+        assertBulkAndSearchTestIndex(GrpcHelpers.secureChannel(getSecureGrpcEndpoint(cluster)));
+    }
+
+    @Test
+    public void testBulkAndSearchUntrustedSecureChannel() throws IOException {
+        assertBulkAndSearchTestIndex(GrpcHelpers.secureUntrustedChannel(getSecureGrpcEndpoint(cluster)));
+    }
+}

--- a/src/integrationTest/java/org/opensearch/security/grpc/GrpcClientAuthOptionalTests.java
+++ b/src/integrationTest/java/org/opensearch/security/grpc/GrpcClientAuthOptionalTests.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+package org.opensearch.security.grpc;
+
+import java.io.IOException;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.opensearch.plugin.transport.grpc.GrpcPlugin;
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.LocalCluster;
+
+import io.grpc.ManagedChannel;
+import io.grpc.StatusRuntimeException;
+
+import static org.opensearch.security.grpc.GrpcClientAuthNoneTests.assertBulkAndSearchTestIndex;
+import static org.opensearch.security.grpc.GrpcHelpers.CLIENT_AUTH_OPT;
+import static org.opensearch.security.grpc.GrpcHelpers.SINGLE_NODE_SECURE_GRPC_TRANSPORT_SETTINGS;
+import static org.opensearch.security.grpc.GrpcHelpers.TEST_CERTIFICATES;
+import static org.opensearch.security.grpc.GrpcHelpers.getSecureGrpcEndpoint;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+@RunWith(com.carrotsearch.randomizedtesting.RandomizedRunner.class)
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class GrpcClientAuthOptionalTests {
+    @ClassRule
+    public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
+        .plugin(GrpcPlugin.class)
+        .certificates(TEST_CERTIFICATES)
+        .nodeSettings(SINGLE_NODE_SECURE_GRPC_TRANSPORT_SETTINGS)
+        .loadConfigurationIntoIndex(false)
+        .sslOnly(true)
+        .nodeSettings(CLIENT_AUTH_OPT)
+        .build();
+
+    @Test
+    public void testPlaintextChannel() {
+        ManagedChannel channel = GrpcHelpers.plaintextChannel(getSecureGrpcEndpoint(cluster));
+        StatusRuntimeException exception = assertThrows(StatusRuntimeException.class, () -> { assertBulkAndSearchTestIndex(channel); });
+        assertEquals("UNAVAILABLE: Network closed for unknown reason", exception.getMessage());
+        channel.shutdown();
+    }
+
+    @Test
+    public void testBulkAndSearchInsecureChannel() {
+        assertBulkAndSearchTestIndex(GrpcHelpers.insecureChannel(getSecureGrpcEndpoint(cluster)));
+    }
+
+    @Test
+    public void testBulkAndSearchSecureChannel() throws IOException {
+        assertBulkAndSearchTestIndex(GrpcHelpers.secureChannel(getSecureGrpcEndpoint(cluster)));
+    }
+
+    @Test
+    public void testBulkAndSearchUntrustedSecureChannel() throws IOException {
+        ManagedChannel channel = GrpcHelpers.secureUntrustedChannel(getSecureGrpcEndpoint(cluster));
+        StatusRuntimeException exception = assertThrows(StatusRuntimeException.class, () -> { assertBulkAndSearchTestIndex(channel); });
+        assertEquals("UNAVAILABLE: ssl exception", exception.getMessage());
+        channel.shutdown();
+    }
+}

--- a/src/integrationTest/java/org/opensearch/security/grpc/GrpcClientAuthRequireTests.java
+++ b/src/integrationTest/java/org/opensearch/security/grpc/GrpcClientAuthRequireTests.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+package org.opensearch.security.grpc;
+
+import java.io.IOException;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.opensearch.plugin.transport.grpc.GrpcPlugin;
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.LocalCluster;
+
+import io.grpc.ManagedChannel;
+import io.grpc.StatusRuntimeException;
+
+import static org.opensearch.security.grpc.GrpcClientAuthNoneTests.assertBulkAndSearchTestIndex;
+import static org.opensearch.security.grpc.GrpcHelpers.CLIENT_AUTH_REQUIRE;
+import static org.opensearch.security.grpc.GrpcHelpers.SINGLE_NODE_SECURE_GRPC_TRANSPORT_SETTINGS;
+import static org.opensearch.security.grpc.GrpcHelpers.TEST_CERTIFICATES;
+import static org.opensearch.security.grpc.GrpcHelpers.getSecureGrpcEndpoint;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+@RunWith(com.carrotsearch.randomizedtesting.RandomizedRunner.class)
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class GrpcClientAuthRequireTests {
+    @ClassRule
+    public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
+        .plugin(GrpcPlugin.class)
+        .certificates(TEST_CERTIFICATES)
+        .nodeSettings(SINGLE_NODE_SECURE_GRPC_TRANSPORT_SETTINGS)
+        .loadConfigurationIntoIndex(false)
+        .sslOnly(true)
+        .nodeSettings(CLIENT_AUTH_REQUIRE)
+        .build();
+
+    @Test
+    public void testPlaintextChannel() {
+        ManagedChannel channel = GrpcHelpers.plaintextChannel(getSecureGrpcEndpoint(cluster));
+        StatusRuntimeException exception = assertThrows(StatusRuntimeException.class, () -> { assertBulkAndSearchTestIndex(channel); });
+        assertEquals("UNAVAILABLE: Network closed for unknown reason", exception.getMessage());
+        channel.shutdown();
+    }
+
+    @Test
+    public void testBulkAndSearchInsecureChannel() {
+        ManagedChannel channel = GrpcHelpers.insecureChannel(getSecureGrpcEndpoint(cluster));
+        StatusRuntimeException exception = assertThrows(StatusRuntimeException.class, () -> { assertBulkAndSearchTestIndex(channel); });
+        assertEquals("UNAVAILABLE: ssl exception", exception.getMessage());
+        channel.shutdown();
+    }
+
+    @Test
+    public void testBulkAndSearchSecureChannel() throws IOException {
+        assertBulkAndSearchTestIndex(GrpcHelpers.secureChannel(getSecureGrpcEndpoint(cluster)));
+    }
+
+    @Test
+    public void testBulkAndSearchUntrustedSecureChannel() throws IOException {
+        ManagedChannel channel = GrpcHelpers.secureUntrustedChannel(getSecureGrpcEndpoint(cluster));
+        StatusRuntimeException exception = assertThrows(StatusRuntimeException.class, () -> { assertBulkAndSearchTestIndex(channel); });
+        assertEquals("UNAVAILABLE: ssl exception", exception.getMessage());
+        channel.shutdown();
+    }
+}

--- a/src/integrationTest/java/org/opensearch/security/grpc/GrpcHelpers.java
+++ b/src/integrationTest/java/org/opensearch/security/grpc/GrpcHelpers.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+package org.opensearch.security.grpc;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.common.transport.PortsRange;
+import org.opensearch.core.common.transport.TransportAddress;
+import org.opensearch.plugin.transport.grpc.ssl.SecureNetty4GrpcServerTransport;
+import org.opensearch.protobufs.BulkRequest;
+import org.opensearch.protobufs.BulkRequestBody;
+import org.opensearch.protobufs.BulkResponse;
+import org.opensearch.protobufs.IndexOperation;
+import org.opensearch.protobufs.MatchAllQuery;
+import org.opensearch.protobufs.QueryContainer;
+import org.opensearch.protobufs.Refresh;
+import org.opensearch.protobufs.SearchRequest;
+import org.opensearch.protobufs.SearchRequestBody;
+import org.opensearch.protobufs.SearchResponse;
+import org.opensearch.protobufs.services.DocumentServiceGrpc;
+import org.opensearch.protobufs.services.SearchServiceGrpc;
+import org.opensearch.test.framework.certificate.TestCertificates;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.LocalOpenSearchCluster;
+
+import io.grpc.ChannelCredentials;
+import io.grpc.Grpc;
+import io.grpc.ManagedChannel;
+import io.grpc.TlsChannelCredentials;
+import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+
+import static com.carrotsearch.randomizedtesting.RandomizedTest.randomFrom;
+import static io.grpc.internal.GrpcUtil.NOOP_PROXY_DETECTOR;
+
+public class GrpcHelpers {
+    protected static final TestCertificates TEST_CERTIFICATES = new TestCertificates();
+    protected static final TestCertificates UN_TRUSTED_TEST_CERTIFICATES = new TestCertificates();
+
+    protected static final Map<String, Object> CLIENT_AUTH_NONE = Map.of(
+        "plugins.security.ssl.aux.experimental-secure-transport-grpc.clientauth_mode",
+        "NONE"
+    );
+
+    protected static final Map<String, Object> CLIENT_AUTH_OPT = Map.of(
+        "plugins.security.ssl.aux.experimental-secure-transport-grpc.clientauth_mode",
+        "OPTIONAL"
+    );
+
+    protected static final Map<String, Object> CLIENT_AUTH_REQUIRE = Map.of(
+        "plugins.security.ssl.aux.experimental-secure-transport-grpc.clientauth_mode",
+        "REQUIRE"
+    );
+
+    private static final PortsRange PORTS_RANGE = new PortsRange("9400-9500");
+
+    public static final Map<String, Object> SINGLE_NODE_SECURE_GRPC_TRANSPORT_SETTINGS = Map.of(
+        "plugins.security.ssl_only",
+        true,
+        "aux.transport.types",
+        "experimental-secure-transport-grpc",
+        "aux.transport.experimental-secure-transport-grpc.port",
+        PORTS_RANGE.getPortRangeString(),
+        "plugins.security.ssl.aux.experimental-secure-transport-grpc.enabled",
+        true,
+        "plugins.security.ssl.aux.experimental-secure-transport-grpc.pemkey_filepath",
+        TEST_CERTIFICATES.getNodeKey(0, null).getAbsolutePath(),
+        "plugins.security.ssl.aux.experimental-secure-transport-grpc.pemcert_filepath",
+        TEST_CERTIFICATES.getNodeCertificate(0).getAbsolutePath(),
+        "plugins.security.ssl.aux.experimental-secure-transport-grpc.pemtrustedcas_filepath",
+        TEST_CERTIFICATES.getRootCertificate().getAbsolutePath()
+    );
+
+    public static TransportAddress getSecureGrpcEndpoint(LocalCluster cluster) {
+        List<TransportAddress> transportAddresses = new ArrayList<>();
+        List<LocalOpenSearchCluster.Node> nodeList = cluster.nodes();
+        for (LocalOpenSearchCluster.Node node : nodeList) {
+            TransportAddress boundAddress = new TransportAddress(
+                node.getInjectable(SecureNetty4GrpcServerTransport.class).getBoundAddress().publishAddress().address()
+            );
+            transportAddresses.add(boundAddress);
+        }
+        return randomFrom(transportAddresses);
+    }
+
+    /*
+    Plaintext connection.
+    No encryption in transit.
+    */
+    public static ManagedChannel plaintextChannel(TransportAddress addr) {
+        return NettyChannelBuilder.forAddress(addr.getAddress(), addr.getPort()).proxyDetector(NOOP_PROXY_DETECTOR).usePlaintext().build();
+    }
+
+    /*
+    TLS with no client certificate.
+    */
+    public static ManagedChannel insecureChannel(TransportAddress addr) {
+        ChannelCredentials credentials = TlsChannelCredentials.newBuilder()
+            .trustManager(InsecureTrustManagerFactory.INSTANCE.getTrustManagers())
+            .build();
+        return Grpc.newChannelBuilderForAddress(addr.getAddress(), addr.getPort(), credentials).build();
+    }
+
+    /*
+    TLS with client certificate trusted by server.
+    */
+    public static ManagedChannel secureChannel(TransportAddress addr) throws IOException {
+        ChannelCredentials credentials = TlsChannelCredentials.newBuilder()
+            .keyManager(TEST_CERTIFICATES.getNodeCertificate(0), TEST_CERTIFICATES.getNodeKey(0, null))
+            .trustManager(InsecureTrustManagerFactory.INSTANCE.getTrustManagers())
+            .build();
+        return Grpc.newChannelBuilderForAddress(addr.getAddress(), addr.getPort(), credentials).build();
+    }
+
+    /*
+    TLS with client certificate not trusted by server.
+    */
+    public static ManagedChannel secureUntrustedChannel(TransportAddress addr) throws IOException {
+        ChannelCredentials credentials = TlsChannelCredentials.newBuilder()
+            .keyManager(UN_TRUSTED_TEST_CERTIFICATES.getNodeCertificate(0), UN_TRUSTED_TEST_CERTIFICATES.getNodeKey(0, null))
+            .trustManager(InsecureTrustManagerFactory.INSTANCE.getTrustManagers())
+            .build();
+        return Grpc.newChannelBuilderForAddress(addr.getAddress(), addr.getPort(), credentials).build();
+    }
+
+    public static BulkResponse doBulk(ManagedChannel channel, String index, long numDocs) {
+        BulkRequest.Builder requestBuilder = BulkRequest.newBuilder().setRefresh(Refresh.REFRESH_TRUE);
+        for (int i = 0; i < numDocs; i++) {
+            String docBody = """
+                {
+                    "field": "doc %d body"
+                }
+                """.formatted(i);
+            IndexOperation indexOp = IndexOperation.newBuilder().setIndex(index).setId(String.valueOf(i)).build();
+            BulkRequestBody requestBody = BulkRequestBody.newBuilder()
+                .setIndex(indexOp)
+                .setDoc(com.google.protobuf.ByteString.copyFromUtf8(docBody))
+                .build();
+            requestBuilder.addRequestBody(requestBody);
+        }
+        DocumentServiceGrpc.DocumentServiceBlockingStub stub = DocumentServiceGrpc.newBlockingStub(channel);
+        return stub.bulk(requestBuilder.build());
+    }
+
+    public static SearchResponse doMatchAll(ManagedChannel channel, String index, int size) {
+        QueryContainer query = QueryContainer.newBuilder().setMatchAll(MatchAllQuery.newBuilder().build()).build();
+        SearchRequestBody requestBody = SearchRequestBody.newBuilder().setSize(size).setQuery(query).build();
+        SearchRequest searchRequest = SearchRequest.newBuilder().addIndex(index).setRequestBody(requestBody).build();
+        SearchServiceGrpc.SearchServiceBlockingStub stub = SearchServiceGrpc.newBlockingStub(channel);
+        return stub.search(searchRequest);
+    }
+}

--- a/src/main/java/org/opensearch/security/configuration/DlsFlsFilterLeafReader.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsFilterLeafReader.java
@@ -902,8 +902,12 @@ class DlsFlsFilterLeafReader extends SequentialStoredFieldsLeafReader {
         return threadContext.getTransient("_opendistro_security_issuggest") == Boolean.TRUE;
     }
 
+    private boolean isParentChildQuery() {
+        return threadContext.getTransient(ConfigConstants.OPENDISTRO_SECURITY_CONTAIN_PARENT_CHILD_QUERY) == Boolean.TRUE;
+    }
+
     private boolean applyDlsHere() {
-        if (isSuggest()) {
+        if (isSuggest() || isParentChildQuery()) {
             // we need to apply it here
             return true;
         }

--- a/src/main/java/org/opensearch/security/dlic/rest/api/ssl/CertificatesInfo.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/ssl/CertificatesInfo.java
@@ -13,9 +13,10 @@ package org.opensearch.security.dlic.rest.api.ssl;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
+import org.opensearch.Version;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
@@ -24,28 +25,61 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.security.ssl.config.CertType;
 
 public class CertificatesInfo implements Writeable, ToXContent {
+    private final Map<String, List<CertificateInfo>> certificates;
 
-    private final Map<CertType, List<CertificateInfo>> certificates;
-
-    public CertificatesInfo(final Map<CertType, List<CertificateInfo>> certificates) {
+    public CertificatesInfo(final Map<String, List<CertificateInfo>> certificates) {
         this.certificates = certificates;
     }
 
     public CertificatesInfo(final StreamInput in) throws IOException {
-        certificates = in.readMap(keyIn -> keyIn.readEnum(CertType.class), listIn -> listIn.readList(CertificateInfo::new));
+        if (in.getVersion().onOrAfter(Version.V_3_2_0)) {
+            certificates = in.readMap(StreamInput::readString, listIn -> listIn.readList(CertificateInfo::new));
+        } else {
+            /*
+            Previous versions represent cert types with an enum and serialize based on
+            enum ordinal. To maintain backwards compatibility we fall back to mapping these
+            enum ordinals to the appropriate native certificate type.
+             */
+            certificates = in.readMap((StreamInput streamIn) -> switch (streamIn.readEnum(CertType.LegacyCertType.class)) {
+                case CertType.LegacyCertType.HTTP -> CertType.HTTP.id();
+                case CertType.LegacyCertType.TRANSPORT -> CertType.TRANSPORT.id();
+                case CertType.LegacyCertType.TRANSPORT_CLIENT -> CertType.TRANSPORT_CLIENT.id();
+            }, listIn -> listIn.readList(CertificateInfo::new));
+        }
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(certificates, StreamOutput::writeEnum, StreamOutput::writeList);
+        if (out.getVersion().onOrAfter(Version.V_3_2_0)) {
+            out.writeMap(certificates, StreamOutput::writeString, StreamOutput::writeList);
+        } else {
+            /*
+            We need to write only map elements which previous versions will understand.
+            CertTypes are strictly bound to LegacyCertType enum in these versions and only has knowledge of
+            HTTP, TRANSPORT, TRANSPORT_CLIENT.
+             */
+            Set<String> legacyCerts = certificates.keySet();
+            legacyCerts.retainAll(List.of(CertType.HTTP.id(), CertType.TRANSPORT.id(), CertType.TRANSPORT_CLIENT.id()));
+            out.writeVInt(legacyCerts.size());
+            for (String certId : legacyCerts) {
+                if (CertType.HTTP.id().equals(certId)) {
+                    out.writeEnum(CertType.LegacyCertType.HTTP);
+                } else if (CertType.TRANSPORT.id().equals(certId)) {
+                    out.writeEnum(CertType.LegacyCertType.TRANSPORT);
+                } else if (CertType.TRANSPORT_CLIENT.id().equals(certId)) {
+                    out.writeEnum(CertType.LegacyCertType.TRANSPORT_CLIENT);
+                }
+                out.writeList(certificates.get(certId));
+            }
+        }
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        return builder.startObject("certificates")
-            .field(CertType.HTTP.name().toLowerCase(Locale.ROOT), certificates.get(CertType.HTTP))
-            .field(CertType.TRANSPORT.name().toLowerCase(Locale.ROOT), certificates.get(CertType.TRANSPORT))
-            .field(CertType.TRANSPORT_CLIENT.name().toLowerCase(Locale.ROOT), certificates.get(CertType.TRANSPORT_CLIENT))
-            .endObject();
+        builder.startObject("certificates");
+        for (Map.Entry<String, List<CertificateInfo>> entry : certificates.entrySet()) {
+            builder.field(entry.getKey(), certificates.get(entry.getKey()));
+        }
+        return builder.endObject();
     }
 }

--- a/src/main/java/org/opensearch/security/dlic/rest/api/ssl/CertificatesInfoNodesRequest.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/ssl/CertificatesInfoNodesRequest.java
@@ -22,25 +22,23 @@ import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.security.ssl.config.CertType;
 
 public class CertificatesInfoNodesRequest extends BaseNodesRequest<CertificatesInfoNodesRequest> {
-
-    private final String certificateType;
-
+    private final String certTypeID;
     private final boolean inMemory;
 
-    public CertificatesInfoNodesRequest(String certificateType, boolean inMemory, String... nodesIds) {
+    public CertificatesInfoNodesRequest(String certTypeID, boolean inMemory, String... nodesIds) {
         super(nodesIds);
-        this.certificateType = certificateType;
+        this.certTypeID = certTypeID;
         this.inMemory = inMemory;
     }
 
     public CertificatesInfoNodesRequest(final StreamInput in) throws IOException {
         super(in);
-        certificateType = in.readOptionalString();
+        certTypeID = in.readOptionalString();
         inMemory = in.readBoolean();
     }
 
     public Optional<String> certificateType() {
-        return Optional.ofNullable(certificateType);
+        return Optional.ofNullable(certTypeID);
     }
 
     public boolean inMemory() {
@@ -50,15 +48,15 @@ public class CertificatesInfoNodesRequest extends BaseNodesRequest<CertificatesI
     @Override
     public void writeTo(final StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeOptionalString(certificateType);
+        out.writeOptionalString(certTypeID);
         out.writeBoolean(inMemory);
     }
 
     @Override
     public ActionRequestValidationException validate() {
-        if (!Strings.isEmpty(certificateType) && !CertType.TYPES.contains(certificateType)) {
+        if (!Strings.isEmpty(certTypeID) && !CertType.CERT_TYPE_REGISTRY.contains(certTypeID)) {
             final var errorMessage = new ActionRequestValidationException();
-            errorMessage.addValidationError("wrong certificate type " + certificateType + ". Please use one of " + CertType.TYPES);
+            errorMessage.addValidationError("wrong certificate type " + certTypeID + ". Please use one of " + CertType.CERT_TYPE_REGISTRY);
             return errorMessage;
         }
         return super.validate();

--- a/src/main/java/org/opensearch/security/dlic/rest/api/ssl/TransportCertificatesInfoNodesAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/ssl/TransportCertificatesInfoNodesAction.java
@@ -12,8 +12,8 @@
 package org.opensearch.security.dlic.rest.api.ssl;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -97,39 +97,18 @@ public class TransportCertificatesInfoNodesAction extends TransportNodesAction<
         }
     }
 
-    protected CertificatesInfo loadCertificates(final Optional<String> certificateType) {
-        var httpCertificates = List.<CertificateInfo>of();
-        var transportCertificates = List.<CertificateInfo>of();
-        var transportClientCertificates = List.<CertificateInfo>of();
-        final var certType = certificateType.map(t -> CertType.valueOf(t.toUpperCase(Locale.ROOT))).orElse(null);
-        if (certType == null || certType == CertType.HTTP) {
-            httpCertificates = sslSettingsManager.sslContextHandler(CertType.HTTP)
-                .map(SslContextHandler::certificates)
-                .map(this::certificatesDetails)
-                .orElse(List.of());
+    protected CertificatesInfo loadCertificates(final Optional<String> loadCertType) {
+        Map<String, List<CertificateInfo>> certInfos = new HashMap<>();
+        for (CertType certType : CertType.CERT_TYPE_REGISTRY) {
+            if (loadCertType.isEmpty() || loadCertType.get().equalsIgnoreCase(certType.id())) {
+                List<CertificateInfo> certs = sslSettingsManager.sslContextHandler(certType)
+                    .map(SslContextHandler::certificates)
+                    .map(this::certificatesDetails)
+                    .orElse(List.of());
+                certInfos.put(certType.id(), certs);
+            }
         }
-        if (certType == null || certType == CertType.TRANSPORT) {
-            transportCertificates = sslSettingsManager.sslContextHandler(CertType.TRANSPORT)
-                .map(SslContextHandler::certificates)
-                .map(this::certificatesDetails)
-                .orElse(List.of());
-        }
-        if (certType == null || certType == CertType.TRANSPORT_CLIENT) {
-            transportClientCertificates = sslSettingsManager.sslContextHandler(CertType.TRANSPORT_CLIENT)
-                .map(SslContextHandler::certificates)
-                .map(this::certificatesDetails)
-                .orElse(List.of());
-        }
-        return new CertificatesInfo(
-            Map.of(
-                CertType.HTTP,
-                httpCertificates,
-                CertType.TRANSPORT,
-                transportCertificates,
-                CertType.TRANSPORT_CLIENT,
-                transportClientCertificates
-            )
-        );
+        return new CertificatesInfo(certInfos);
     }
 
     private List<CertificateInfo> certificatesDetails(final Stream<Certificate> certificateStream) {

--- a/src/main/java/org/opensearch/security/ssl/DefaultSecurityKeyStore.java
+++ b/src/main/java/org/opensearch/security/ssl/DefaultSecurityKeyStore.java
@@ -67,6 +67,7 @@ import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.SpecialPermission;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.env.Environment;
+import org.opensearch.security.ssl.config.CertType;
 import org.opensearch.security.ssl.util.CertFileProps;
 import org.opensearch.security.ssl.util.CertFromFile;
 import org.opensearch.security.ssl.util.CertFromKeystore;
@@ -806,16 +807,16 @@ public class DefaultSecurityKeyStore implements SecurityKeyStore {
     private void initEnabledSSLCiphers() {
 
         final ImmutableSet<String> allowedSecureHttpSSLCiphers = ImmutableSet.copyOf(
-            SSLConfigConstants.getSecureSSLCiphers(settings, true)
+            SSLConfigConstants.getSecureSSLCiphers(settings, CertType.HTTP)
         );
         final ImmutableSet<String> allowedSecureTransportSSLCiphers = ImmutableSet.copyOf(
-            SSLConfigConstants.getSecureSSLCiphers(settings, false)
+            SSLConfigConstants.getSecureSSLCiphers(settings, CertType.TRANSPORT)
         );
         final ImmutableSet<String> allowedSecureHttpSSLProtocols = ImmutableSet.copyOf(
-            (SSLConfigConstants.getSecureSSLProtocols(settings, true))
+            (SSLConfigConstants.getSecureSSLProtocols(settings, CertType.HTTP))
         );
         final ImmutableSet<String> allowedSecureTransportSSLProtocols = ImmutableSet.copyOf(
-            SSLConfigConstants.getSecureSSLProtocols(settings, false)
+            SSLConfigConstants.getSecureSSLProtocols(settings, CertType.TRANSPORT)
         );
 
         SSLEngine engine = null;

--- a/src/main/java/org/opensearch/security/ssl/ExternalSecurityKeyStore.java
+++ b/src/main/java/org/opensearch/security/ssl/ExternalSecurityKeyStore.java
@@ -31,6 +31,7 @@ import javax.net.ssl.SSLParameters;
 
 import org.opensearch.OpenSearchException;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.security.ssl.config.CertType;
 import org.opensearch.security.ssl.util.SSLConfigConstants;
 
 public class ExternalSecurityKeyStore implements SecurityKeyStore {
@@ -72,17 +73,27 @@ public class ExternalSecurityKeyStore implements SecurityKeyStore {
             final SSLParameters sslParams = new SSLParameters();
             sslParams.setEndpointIdentificationAlgorithm("HTTPS");
             engine.setSSLParameters(sslParams);
-            engine.setEnabledProtocols(evalSecure(engine.getEnabledProtocols(), SSLConfigConstants.getSecureSSLProtocols(settings, false)));
+            engine.setEnabledProtocols(
+                evalSecure(engine.getEnabledProtocols(), SSLConfigConstants.getSecureSSLProtocols(settings, CertType.TRANSPORT))
+            );
             engine.setEnabledCipherSuites(
-                evalSecure(engine.getEnabledCipherSuites(), SSLConfigConstants.getSecureSSLCiphers(settings, false).toArray(new String[0]))
+                evalSecure(
+                    engine.getEnabledCipherSuites(),
+                    SSLConfigConstants.getSecureSSLCiphers(settings, CertType.TRANSPORT).toArray(new String[0])
+                )
             );
             engine.setUseClientMode(true);
             return engine;
         } else {
             final SSLEngine engine = externalSslContext.createSSLEngine();
-            engine.setEnabledProtocols(evalSecure(engine.getEnabledProtocols(), SSLConfigConstants.getSecureSSLProtocols(settings, false)));
+            engine.setEnabledProtocols(
+                evalSecure(engine.getEnabledProtocols(), SSLConfigConstants.getSecureSSLProtocols(settings, CertType.TRANSPORT))
+            );
             engine.setEnabledCipherSuites(
-                evalSecure(engine.getEnabledCipherSuites(), SSLConfigConstants.getSecureSSLCiphers(settings, false).toArray(new String[0]))
+                evalSecure(
+                    engine.getEnabledCipherSuites(),
+                    SSLConfigConstants.getSecureSSLCiphers(settings, CertType.TRANSPORT).toArray(new String[0])
+                )
             );
             engine.setUseClientMode(true);
             return engine;

--- a/src/main/java/org/opensearch/security/ssl/OpenSearchSecuritySSLPlugin.java
+++ b/src/main/java/org/opensearch/security/ssl/OpenSearchSecuritySSLPlugin.java
@@ -94,6 +94,17 @@ import org.opensearch.watcher.ResourceWatcherService;
 import io.netty.handler.ssl.OpenSsl;
 import io.netty.util.internal.PlatformDependent;
 
+import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_AUX_CLIENTAUTH_MODE;
+import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_AUX_ENABLED;
+import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_AUX_ENABLED_CIPHERS;
+import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_AUX_ENABLED_PROTOCOLS;
+import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_AUX_KEYSTORE_FILEPATH;
+import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_AUX_PEMCERT_FILEPATH;
+import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_AUX_PEMKEY_FILEPATH;
+import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_AUX_PEMKEY_PASSWORD;
+import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_AUX_PEMTRUSTEDCAS_FILEPATH;
+import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_AUX_TRUSTSTORE_FILEPATH;
+
 //For ES5 this class has only effect when SSL only plugin is installed
 public class OpenSearchSecuritySSLPlugin extends Plugin implements SystemIndexPlugin, NetworkPlugin {
     private static final Setting<Boolean> SECURITY_SSL_TRANSPORT_ENFORCE_HOSTNAME_VERIFICATION = Setting.boolSetting(
@@ -631,6 +642,24 @@ public class OpenSearchSecuritySSLPlugin extends Plugin implements SystemIndexPl
                 true,
                 Property.NodeScope,
                 Property.Filtered
+            )
+        );
+
+        /**
+         * Expose aux transport settings.
+         */
+        settings.addAll(
+            List.of(
+                SECURITY_SSL_AUX_ENABLED,
+                SECURITY_SSL_AUX_ENABLED_CIPHERS,
+                SECURITY_SSL_AUX_ENABLED_PROTOCOLS,
+                SECURITY_SSL_AUX_KEYSTORE_FILEPATH,
+                SECURITY_SSL_AUX_PEMKEY_FILEPATH,
+                SECURITY_SSL_AUX_PEMKEY_PASSWORD,
+                SECURITY_SSL_AUX_PEMCERT_FILEPATH,
+                SECURITY_SSL_AUX_CLIENTAUTH_MODE,
+                SECURITY_SSL_AUX_TRUSTSTORE_FILEPATH,
+                SECURITY_SSL_AUX_PEMTRUSTEDCAS_FILEPATH
             )
         );
 

--- a/src/main/java/org/opensearch/security/ssl/SslSettingsManager.java
+++ b/src/main/java/org/opensearch/security/ssl/SslSettingsManager.java
@@ -27,17 +27,22 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import org.opensearch.OpenSearchException;
+import org.opensearch.common.collect.Tuple;
+import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.env.Environment;
 import org.opensearch.security.ssl.config.CertType;
+import org.opensearch.security.ssl.config.KeyStoreConfiguration;
 import org.opensearch.security.ssl.config.SslCertificatesLoader;
 import org.opensearch.security.ssl.config.SslParameters;
+import org.opensearch.security.ssl.config.TrustStoreConfiguration;
 import org.opensearch.watcher.FileChangesListener;
 import org.opensearch.watcher.FileWatcher;
 import org.opensearch.watcher.ResourceWatcherService;
 
 import io.netty.handler.ssl.ClientAuth;
 
+import static org.opensearch.security.ssl.config.CertType.CERT_TYPE_REGISTRY;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.CLIENT_AUTH_MODE;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.ENABLED;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.EXTENDED_KEY_USAGE_ENABLED;
@@ -46,12 +51,8 @@ import static org.opensearch.security.ssl.util.SSLConfigConstants.KEYSTORE_FILEP
 import static org.opensearch.security.ssl.util.SSLConfigConstants.PEM_CERT_FILEPATH;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.PEM_KEY_FILEPATH;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.PEM_TRUSTED_CAS_FILEPATH;
+import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_AUX_ENABLED;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_HTTP_ENABLED_DEFAULT;
-import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_HTTP_KEYSTORE_FILEPATH;
-import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_HTTP_PEMCERT_FILEPATH;
-import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_HTTP_PEMKEY_FILEPATH;
-import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_HTTP_PEMTRUSTEDCAS_FILEPATH;
-import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_HTTP_TRUSTSTORE_FILEPATH;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_TRANSPORT_CLIENT_KEYSTORE_ALIAS;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_TRANSPORT_CLIENT_PEMCERT_FILEPATH;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_TRANSPORT_CLIENT_PEMKEY_FILEPATH;
@@ -68,10 +69,12 @@ import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_T
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_TRANSPORT_SERVER_PEMKEY_FILEPATH;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_TRANSPORT_SERVER_PEMTRUSTEDCAS_FILEPATH;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_TRANSPORT_SERVER_TRUSTSTORE_ALIAS;
+import static org.opensearch.security.ssl.util.SSLConfigConstants.SSL_AUX_PREFIX;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SSL_TRANSPORT_CLIENT_EXTENDED_PREFIX;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SSL_TRANSPORT_SERVER_EXTENDED_PREFIX;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.TRUSTSTORE_ALIAS;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.TRUSTSTORE_FILEPATH;
+import static org.opensearch.transport.AuxTransport.AUX_TRANSPORT_TYPES_SETTING;
 
 public class SslSettingsManager {
 
@@ -87,24 +90,38 @@ public class SslSettingsManager {
         return Optional.ofNullable(sslSettingsContexts.get(certType)).map(SslContextHandler::sslConfiguration);
     }
 
-    public Optional<SslContextHandler> sslContextHandler(final CertType sslConfigPrefix) {
-        return Optional.ofNullable(sslSettingsContexts.get(sslConfigPrefix));
+    public Optional<SslContextHandler> sslContextHandler(final CertType certType) {
+        return Optional.ofNullable(sslSettingsContexts.get(certType));
     }
 
+    /**
+     * Load and validate environment configuration for available CertTypes.
+     * @param environment settings and JDK environment.
+     */
     private Map<CertType, SslContextHandler> buildSslContexts(final Environment environment) {
-        final var contexts = new ImmutableMap.Builder<CertType, SslContextHandler>();
-        final var configurations = loadConfigurations(environment);
-        Optional.ofNullable(configurations.get(CertType.HTTP))
-            .ifPresentOrElse(
-                sslConfiguration -> contexts.put(CertType.HTTP, new SslContextHandler(sslConfiguration)),
-                () -> LOGGER.warn("SSL Configuration for HTTP Layer hasn't been set")
-            );
-        Optional.ofNullable(configurations.get(CertType.TRANSPORT)).ifPresentOrElse(sslConfiguration -> {
-            contexts.put(CertType.TRANSPORT, new SslContextHandler(sslConfiguration));
-            final var transportClientConfiguration = Optional.ofNullable(configurations.get(CertType.TRANSPORT_CLIENT))
-                .orElse(sslConfiguration);
-            contexts.put(CertType.TRANSPORT_CLIENT, new SslContextHandler(transportClientConfiguration, true));
-        }, () -> LOGGER.warn("SSL Configuration for Transport Layer hasn't been set"));
+        final ImmutableMap.Builder<CertType, SslContextHandler> contexts = new ImmutableMap.Builder<>();
+        final Map<CertType, SslConfiguration> configurations = loadConfigurations(environment);
+        configurations.forEach((cert, sslConfig) -> {
+            // TRANSPORT/TRANSPORT_CLIENT are exceptions.
+            if (cert == CertType.TRANSPORT) {
+                Optional.ofNullable(configurations.get(CertType.TRANSPORT)).ifPresentOrElse(sslConfiguration -> {
+                    contexts.put(CertType.TRANSPORT, new SslContextHandler(sslConfiguration));
+                    final var transportClientConfiguration = Optional.ofNullable(configurations.get(CertType.TRANSPORT_CLIENT))
+                        .orElse(sslConfiguration);
+                    contexts.put(CertType.TRANSPORT_CLIENT, new SslContextHandler(transportClientConfiguration, true));
+                }, () -> LOGGER.warn("SSL Configuration for Transport Layer hasn't been set"));
+                return;
+            } else if (cert == CertType.TRANSPORT_CLIENT) {
+                return; // TRANSPORT_CLIENT is handled in TRANSPORT case. Skip.
+            }
+
+            // Load all other configurations into SslContextHandlers.
+            Optional.ofNullable(configurations.get(cert))
+                .ifPresentOrElse(
+                    sslConfiguration -> contexts.put(cert, new SslContextHandler(sslConfiguration)),
+                    () -> LOGGER.warn("SSL Configuration for {} Layer hasn't been set", cert.id())
+                );
+        });
         return contexts.build();
     }
 
@@ -112,31 +129,54 @@ public class SslSettingsManager {
         sslContextHandler(certType).ifPresentOrElse(sscContextHandler -> {
             try {
                 if (sscContextHandler.reloadSslContext()) {
-                    LOGGER.info("{} SSL context reloaded", certType.name());
+                    LOGGER.info("{} SSL context reloaded", certType.id());
                 }
             } catch (CertificateException e) {
                 throw new OpenSearchException(e);
             }
-        }, () -> LOGGER.error("Missing SSL Context for {}", certType.name()));
+        }, () -> LOGGER.error("Missing SSL Context for {}", certType.id()));
     }
 
     private Map<CertType, SslConfiguration> loadConfigurations(final Environment environment) {
-        final var settings = environment.settings();
-        final var httpSettings = settings.getByPrefix(CertType.HTTP.sslConfigPrefix());
-        final var transportSettings = settings.getByPrefix(CertType.TRANSPORT.sslConfigPrefix());
-        if (httpSettings.isEmpty() && transportSettings.isEmpty()) {
+        final Settings settings = environment.settings();
+        final ImmutableMap.Builder<CertType, SslConfiguration> configurationBuilder = ImmutableMap.builder();
+        if (settings.getByPrefix(CertType.HTTP.sslSettingPrefix()).isEmpty()
+            && settings.getByPrefix(CertType.TRANSPORT.sslSettingPrefix()).isEmpty()) {
             throw new OpenSearchException("No SSL configuration found");
         }
         jceWarnings();
 
-        final var httpEnabled = httpSettings.getAsBoolean(ENABLED, SECURITY_SSL_HTTP_ENABLED_DEFAULT);
-        final var transportEnabled = transportSettings.getAsBoolean(ENABLED, SECURITY_SSL_TRANSPORT_ENABLED_DEFAULT);
+        /*
+         * Fetch and load configurations for available aux transports.
+         * Registered all configured aux transports as new CertTypes.
+         */
+        for (String auxType : AUX_TRANSPORT_TYPES_SETTING.get(environment.settings())) {
+            final CertType auxCert = new CertType(SSL_AUX_PREFIX + auxType + ".");
+            final Setting<Boolean> auxEnabled = SECURITY_SSL_AUX_ENABLED.getConcreteSettingForNamespace(auxType);
+            CERT_TYPE_REGISTRY.register(auxCert);
+            if (auxEnabled.get(settings) && !clientNode(settings)) {
+                validateSettings(auxCert, settings, false);
+                final SslParameters auxSslParameters = SslParameters.loader(auxCert, settings).load();
+                final Tuple<TrustStoreConfiguration, KeyStoreConfiguration> auxTrustAndKeyStore = new SslCertificatesLoader(
+                    auxCert.sslSettingPrefix()
+                ).loadConfiguration(environment);
+                configurationBuilder.put(
+                    auxCert,
+                    new SslConfiguration(auxSslParameters, auxTrustAndKeyStore.v1(), auxTrustAndKeyStore.v2())
+                );
+                LOGGER.info("TLS {} Provider                    : {}", auxCert.id(), auxSslParameters.provider());
+                LOGGER.info("Enabled TLS protocols for {} layer : {}", auxCert.id(), auxSslParameters.allowedProtocols());
+            }
+        }
 
-        final var configurationBuilder = ImmutableMap.<CertType, SslConfiguration>builder();
+        /*
+         * Load HTTP SslConfiguration.
+         */
+        final boolean httpEnabled = settings.getAsBoolean(CertType.HTTP.sslSettingPrefix() + ENABLED, SECURITY_SSL_HTTP_ENABLED_DEFAULT);
         if (httpEnabled && !clientNode(settings)) {
-            validateHttpSettings(httpSettings);
-            final var httpSslParameters = SslParameters.loader(httpSettings).load(true);
-            final var httpTrustAndKeyStore = new SslCertificatesLoader(CertType.HTTP.sslConfigPrefix()).loadConfiguration(environment);
+            validateSettings(CertType.HTTP, settings, SECURITY_SSL_HTTP_ENABLED_DEFAULT);
+            final var httpSslParameters = SslParameters.loader(CertType.HTTP, settings).load();
+            final var httpTrustAndKeyStore = new SslCertificatesLoader(CertType.HTTP.sslSettingPrefix()).loadConfiguration(environment);
             configurationBuilder.put(
                 CertType.HTTP,
                 new SslConfiguration(httpSslParameters, httpTrustAndKeyStore.v1(), httpTrustAndKeyStore.v2())
@@ -144,12 +184,17 @@ public class SslSettingsManager {
             LOGGER.info("TLS HTTP Provider                    : {}", httpSslParameters.provider());
             LOGGER.info("Enabled TLS protocols for HTTP layer : {}", httpSslParameters.allowedProtocols());
         }
-        final var transportSslParameters = SslParameters.loader(transportSettings).load(false);
-        if (transportEnabled) {
+
+        /*
+         * Load transport layer SslConfigurations.
+         */
+        final Settings transportSettings = settings.getByPrefix(CertType.TRANSPORT.sslSettingPrefix());
+        final SslParameters transportSslParameters = SslParameters.loader(CertType.TRANSPORT, settings).load();
+        if (transportSettings.getAsBoolean(ENABLED, SECURITY_SSL_TRANSPORT_ENABLED_DEFAULT)) {
             if (hasExtendedKeyUsageEnabled(transportSettings)) {
                 validateTransportSettings(transportSettings);
                 final var transportServerTrustAndKeyStore = new SslCertificatesLoader(
-                    CertType.TRANSPORT.sslConfigPrefix(),
+                    CertType.TRANSPORT.sslSettingPrefix(),
                     SSL_TRANSPORT_SERVER_EXTENDED_PREFIX
                 ).loadConfiguration(environment);
                 configurationBuilder.put(
@@ -157,7 +202,7 @@ public class SslSettingsManager {
                     new SslConfiguration(transportSslParameters, transportServerTrustAndKeyStore.v1(), transportServerTrustAndKeyStore.v2())
                 );
                 final var transportClientTrustAndKeyStore = new SslCertificatesLoader(
-                    CertType.TRANSPORT.sslConfigPrefix(),
+                    CertType.TRANSPORT.sslSettingPrefix(),
                     SSL_TRANSPORT_CLIENT_EXTENDED_PREFIX
                 ).loadConfiguration(environment);
                 configurationBuilder.put(
@@ -166,7 +211,7 @@ public class SslSettingsManager {
                 );
             } else {
                 validateTransportSettings(transportSettings);
-                final var transportTrustAndKeyStore = new SslCertificatesLoader(CertType.TRANSPORT.sslConfigPrefix()).loadConfiguration(
+                final var transportTrustAndKeyStore = new SslCertificatesLoader(CertType.TRANSPORT.sslSettingPrefix()).loadConfiguration(
                     environment
                 );
                 configurationBuilder.put(
@@ -229,38 +274,94 @@ public class SslSettingsManager {
         return !"node".equals(settings.get(OpenSearchSecuritySSLPlugin.CLIENT_TYPE));
     }
 
-    private void validateHttpSettings(final Settings httpSettings) {
-        if (httpSettings == null) return;
-        if (!httpSettings.getAsBoolean(ENABLED, SECURITY_SSL_HTTP_ENABLED_DEFAULT)) return;
-
-        final var clientAuth = ClientAuth.valueOf(httpSettings.get(CLIENT_AUTH_MODE, ClientAuth.OPTIONAL.name()).toUpperCase(Locale.ROOT));
-
-        if (hasPemStoreSettings(httpSettings)) {
-            if (!httpSettings.hasValue(PEM_CERT_FILEPATH) || !httpSettings.hasValue(PEM_KEY_FILEPATH)) {
-                throw new OpenSearchException(
-                    "Wrong HTTP SSL configuration. "
-                        + String.join(", ", SECURITY_SSL_HTTP_PEMCERT_FILEPATH, SECURITY_SSL_HTTP_PEMKEY_FILEPATH)
-                        + " must be set"
-                );
-            }
-            if (clientAuth == ClientAuth.REQUIRE && !httpSettings.hasValue(PEM_TRUSTED_CAS_FILEPATH)) {
-                throw new OpenSearchException(
-                    "Wrong HTTP SSL configuration. " + SECURITY_SSL_HTTP_PEMTRUSTEDCAS_FILEPATH + " must be set if client auth is required"
-                );
-            }
-        } else if (hasKeyOrTrustStoreSettings(httpSettings)) {
-            if (!httpSettings.hasValue(KEYSTORE_FILEPATH)) {
-                throw new OpenSearchException("Wrong HTTP SSL configuration. " + SECURITY_SSL_HTTP_KEYSTORE_FILEPATH + " must be set");
-            }
-            if (clientAuth == ClientAuth.REQUIRE && !httpSettings.hasValue(TRUSTSTORE_FILEPATH)) {
-                throw new OpenSearchException(
-                    "Wrong HTTP SSL configuration. " + SECURITY_SSL_HTTP_TRUSTSTORE_FILEPATH + " must be set if client auth is required"
-                );
-            }
+    /**
+     * Validates configuration of transport pem store/keystore for provided CertType.
+     * {@link org.opensearch.OpenSearchException} thrown on invalid config.
+     * @param certType cert type to validate.
+     * @param settings {@link org.opensearch.env.Environment} settings.
+     */
+    private void validateSettings(final CertType certType, final Settings settings, final boolean enabled_default) {
+        final Settings certSettings = settings.getByPrefix(certType.sslSettingPrefix());
+        if (certSettings.isEmpty()) return;
+        if (!certSettings.getAsBoolean(ENABLED, enabled_default)) return;
+        if (hasPemStoreSettings(certSettings)) {
+            validatePemStoreSettings(certType, settings);
+        } else if (hasKeyOrTrustStoreSettings(certSettings)) {
+            validateKeyStoreSettings(certType, settings);
         } else {
             throw new OpenSearchException(
-                "Wrong HTTP SSL configuration. One of Keystore and Truststore files or X.509 PEM certificates and "
-                    + "PKCS#8 keys groups should be set to configure HTTP layer"
+                "Wrong "
+                    + certType.id()
+                    + " SSL configuration. One of Keystore and Truststore files or X.509 PEM certificates and "
+                    + "PKCS#8 keys groups should be set to configure "
+                    + certType.id()
+                    + " layer"
+            );
+        }
+    }
+
+    /**
+     * Validate pem store settings for transport of given type.
+     * Throws an {@link org.opensearch.OpenSearchException} if:
+     * - Either of the pem certificate or pem private key paths are not set.
+     * - Client auth is set to REQUIRE but pem trusted certificates filepath is not set.
+     * @param transportType transport type to validate
+     * @param settings {@link org.opensearch.env.Environment} settings.
+     */
+    private void validatePemStoreSettings(CertType transportType, final Settings settings) throws OpenSearchException {
+        final var transportSettings = settings.getByPrefix(transportType.sslSettingPrefix());
+        final var clientAuth = ClientAuth.valueOf(
+            transportSettings.get(CLIENT_AUTH_MODE, ClientAuth.OPTIONAL.name()).toUpperCase(Locale.ROOT)
+        );
+        if (!transportSettings.hasValue(PEM_CERT_FILEPATH) || !transportSettings.hasValue(PEM_KEY_FILEPATH)) {
+            throw new OpenSearchException(
+                "Wrong "
+                    + transportType.id().toLowerCase(Locale.ROOT)
+                    + " SSL configuration. "
+                    + String.join(", ", transportSettings.get(PEM_CERT_FILEPATH), transportSettings.get(PEM_KEY_FILEPATH))
+                    + " must be set"
+            );
+        }
+        if (clientAuth == ClientAuth.REQUIRE && !transportSettings.hasValue(PEM_TRUSTED_CAS_FILEPATH)) {
+            throw new OpenSearchException(
+                "Wrong "
+                    + transportType.id().toLowerCase(Locale.ROOT)
+                    + " SSL configuration. "
+                    + PEM_TRUSTED_CAS_FILEPATH
+                    + " must be set if client auth is required"
+            );
+        }
+    }
+
+    /**
+     * Validate key store settings for transport of given type.
+     * Throws an {@link org.opensearch.OpenSearchException} if:
+     * - Keystore filepath is not set.
+     * - Client auth is set to REQUIRE but trust store filepath is not set.
+     * @param transportType transport type to validate
+     * @param settings {@link org.opensearch.env.Environment} settings.
+     */
+    private void validateKeyStoreSettings(CertType transportType, final Settings settings) throws OpenSearchException {
+        final var transportSettings = settings.getByPrefix(transportType.sslSettingPrefix());
+        final var clientAuth = ClientAuth.valueOf(
+            transportSettings.get(CLIENT_AUTH_MODE, ClientAuth.OPTIONAL.name()).toUpperCase(Locale.ROOT)
+        );
+        if (!transportSettings.hasValue(KEYSTORE_FILEPATH)) {
+            throw new OpenSearchException(
+                "Wrong "
+                    + transportType.id().toLowerCase(Locale.ROOT)
+                    + " SSL configuration. "
+                    + transportSettings.get(KEYSTORE_FILEPATH)
+                    + " must be set"
+            );
+        }
+        if (clientAuth == ClientAuth.REQUIRE && !transportSettings.hasValue(TRUSTSTORE_FILEPATH)) {
+            throw new OpenSearchException(
+                "Wrong "
+                    + transportType.id().toLowerCase(Locale.ROOT)
+                    + " SSL configuration. "
+                    + TRUSTSTORE_FILEPATH
+                    + " must be set if client auth is required"
             );
         }
     }
@@ -386,5 +487,4 @@ public class SslSettingsManager {
             LOGGER.error("AES encryption not supported (SG 1). ", e);
         }
     }
-
 }

--- a/src/main/java/org/opensearch/security/ssl/config/CertType.java
+++ b/src/main/java/org/opensearch/security/ssl/config/CertType.java
@@ -11,32 +11,126 @@
 
 package org.opensearch.security.ssl.config;
 
-import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Locale;
+import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SSL_HTTP_PREFIX;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SSL_TRANSPORT_CLIENT_PREFIX;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SSL_TRANSPORT_PREFIX;
 
-public enum CertType {
-    HTTP(SSL_HTTP_PREFIX),
-    TRANSPORT(SSL_TRANSPORT_PREFIX),
-    TRANSPORT_CLIENT(SSL_TRANSPORT_CLIENT_PREFIX);
+/**
+ * CertTypes identify the setting prefix under which configuration settings for a set of certificates
+ * are located as well as the id which uniquely identifies a certificate type to the end user.
+ * CertTypes have a 1-to-1 relationship with ssl contexts and are registered in the global
+ * CERT_TYPE_REGISTRY but default for mandatory transports, or dynamically for pluggable auxiliary transports.
+ */
+public class CertType {
+    private final String certSettingPrefix;
+    private final String certID;
 
-    public static Set<String> TYPES = Arrays.stream(CertType.values())
-        .map(CertType::name)
-        .map(String::toLowerCase)
-        .collect(Collectors.toSet());
-
-    private final String sslConfigPrefix;
-
-    private CertType(String sslConfigPrefix) {
-        this.sslConfigPrefix = sslConfigPrefix;
+    /**
+     * In most cases the certID is the last element of the setting prefix.
+     * We expect this to be the case for all auxiliary transports.
+     * Exceptions where this pattern does not hold include:
+     * "plugins.security.ssl.transport.server."
+     * "plugins.security.ssl.transport.client."
+     * Where users identify these certificates respectively as:
+     * "transport_server" & "transport_client"
+     */
+    public CertType(String certSettingPrefix) {
+        this.certSettingPrefix = certSettingPrefix;
+        String[] parts = certSettingPrefix.split("\\.");
+        this.certID = parts[parts.length - 1].toLowerCase(Locale.ROOT);
     }
 
-    public String sslConfigPrefix() {
-        return sslConfigPrefix;
+    public CertType(String certSettingPrefix, String certID) {
+        this.certSettingPrefix = certSettingPrefix;
+        this.certID = certID;
     }
 
+    public String sslSettingPrefix() {
+        return certSettingPrefix;
+    }
+
+    public String id() {
+        return this.certID;
+    }
+
+    @Override
+    public String toString() {
+        return this.id();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CertType certType = (CertType) o;
+        return this.id().equals(certType.id());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.id());
+    }
+
+    /**
+     * Write only set for tracking certificate types discovered and registered on a node.
+     * Not all ssl context configurations are known at compile time, so we track newly discovered CertTypes here.
+     */
+    public static class NodeCertTypeRegistry implements Iterable<CertType> {
+        private final Set<CertType> registeredCertType = new HashSet<>();
+
+        public NodeCertTypeRegistry(CertType... initialCertTypes) {
+            for (CertType certType : initialCertTypes) {
+                register(certType);
+            }
+        }
+
+        public void register(CertType certType) {
+            registeredCertType.add(certType);
+        }
+
+        public boolean contains(CertType certType) {
+            return registeredCertType.contains(certType);
+        }
+
+        public boolean contains(String certID) {
+            for (CertType certType : registeredCertType) {
+                if (Objects.equals(certType.id(), certID)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @Nonnull
+        @Override
+        public Iterator<CertType> iterator() {
+            return Collections.unmodifiableSet(registeredCertType).iterator();
+        }
+    }
+
+    /*
+    Mandatory transports.
+    */
+    public static CertType HTTP = new CertType(SSL_HTTP_PREFIX);
+    public static CertType TRANSPORT = new CertType(SSL_TRANSPORT_PREFIX);
+    public static CertType TRANSPORT_CLIENT = new CertType(SSL_TRANSPORT_CLIENT_PREFIX, "transport_client");
+    public static final NodeCertTypeRegistry CERT_TYPE_REGISTRY = new NodeCertTypeRegistry(HTTP, TRANSPORT, TRANSPORT_CLIENT);
+
+    /*
+    Deprecated static certificate types.
+    Only for backwards compatibility on node-to-node transport.
+     */
+    public enum LegacyCertType {
+        HTTP,
+        TRANSPORT,
+        TRANSPORT_CLIENT;
+    }
 }

--- a/src/main/java/org/opensearch/security/ssl/transport/SPIFFEPrincipalExtractor.java
+++ b/src/main/java/org/opensearch/security/ssl/transport/SPIFFEPrincipalExtractor.java
@@ -1,0 +1,74 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.ssl.transport;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.security.cert.CertificateParsingException;
+import java.security.cert.X509Certificate;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class SPIFFEPrincipalExtractor implements PrincipalExtractor {
+    /**
+     * PrincipalExtractor implementation that extracts a SPIFFE URI from an X.509 certificate's SAN.
+     * Returns "CN=spiffe://..." if found, otherwise null.
+     * Used for SPIFFE X.509 SVID-based authentication in OpenSearch clusters.
+     */
+
+    protected final Logger log = LogManager.getLogger(this.getClass());
+
+    @Override
+    @SuppressWarnings("removal")
+    public String extractPrincipal(final X509Certificate x509Certificate, final Type type) {
+        if (x509Certificate == null) {
+            return null;
+        }
+
+        final Collection<List<?>> altNames = AccessController.doPrivileged(new PrivilegedAction<Collection<List<?>>>() {
+            @Override
+            public Collection<List<?>> run() {
+                try {
+                    return x509Certificate.getSubjectAlternativeNames();
+                } catch (CertificateParsingException e) {
+                    log.error("Unable to parse X509 altNames", e);
+                    return null;
+                }
+            }
+        });
+
+        if (altNames == null) {
+            return null;
+        }
+
+        for (List<?> sanItem : altNames) {
+            if (sanItem == null || sanItem.size() < 2) {
+                continue;
+            }
+            Integer altNameType = (Integer) sanItem.get(0);
+            Object altNameValue = sanItem.get(1);
+            if (altNameType != null && altNameType == 6 && altNameValue instanceof String) {
+                String uriValue = (String) altNameValue;
+                if (uriValue.startsWith("spiffe://")) {
+                    if (log.isTraceEnabled()) {
+                        log.trace("principal: CN={}", uriValue);
+                    }
+                    return String.format("CN=%s", uriValue);
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/opensearch/security/support/ConfigConstants.java
+++ b/src/main/java/org/opensearch/security/support/ConfigConstants.java
@@ -71,6 +71,7 @@ public class ConfigConstants {
     public static final String OPENDISTRO_SECURITY_DOC_ALLOWLIST_TRANSIENT = OPENDISTRO_SECURITY_CONFIG_PREFIX + "doc_allowlist_t";
 
     public static final String OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE = OPENDISTRO_SECURITY_CONFIG_PREFIX + "filter_level_dls_done";
+    public static final String OPENDISTRO_SECURITY_CONTAIN_PARENT_CHILD_QUERY = OPENDISTRO_SECURITY_CONFIG_PREFIX + "is_parent_child_query";
 
     public static final String OPENDISTRO_SECURITY_DLS_QUERY_CCS = OPENDISTRO_SECURITY_CONFIG_PREFIX + "dls_query_ccs";
 

--- a/src/main/java/org/opensearch/security/transport/SecurityRequestHandler.java
+++ b/src/main/java/org/opensearch/security/transport/SecurityRequestHandler.java
@@ -55,6 +55,7 @@ import org.opensearch.security.support.Base64Helper;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.support.HeaderHelper;
 import org.opensearch.security.user.UserFactory;
+import org.opensearch.security.util.ParentChildrenQueryDetector;
 import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportChannel;
@@ -139,6 +140,11 @@ public class SecurityRequestHandler<T extends TransportRequest> extends Security
                 ShardSearchRequest sr = ((ShardSearchRequest) request);
                 if (sr.source() != null && sr.source().suggest() != null) {
                     getThreadContext().putTransient("_opendistro_security_issuggest", Boolean.TRUE);
+                }
+                if (sr.source() != null && sr.source().query() != null) {
+                    if (ParentChildrenQueryDetector.hasParentOrChildQuery(sr.source().query())) {
+                        getThreadContext().putTransient(ConfigConstants.OPENDISTRO_SECURITY_CONTAIN_PARENT_CHILD_QUERY, Boolean.TRUE);
+                    }
                 }
             }
 

--- a/src/main/java/org/opensearch/security/util/ParentChildrenQueryDetector.java
+++ b/src/main/java/org/opensearch/security/util/ParentChildrenQueryDetector.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+package org.opensearch.security.util;
+
+import org.apache.lucene.search.BooleanClause;
+
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilderVisitor;
+import org.opensearch.join.query.HasChildQueryBuilder;
+import org.opensearch.join.query.HasParentQueryBuilder;
+
+public final class ParentChildrenQueryDetector implements QueryBuilderVisitor {
+
+    private boolean queryPresent = false;
+
+    private ParentChildrenQueryDetector() {
+        // Private constructor to prevent instantiation
+    }
+
+    public static boolean hasParentOrChildQuery(QueryBuilder queryBuilder) {
+        ParentChildrenQueryDetector detector = new ParentChildrenQueryDetector();
+        queryBuilder.visit(detector);
+        return detector.hasParentOrChildQuery();
+    }
+
+    /**
+     * Do not call the method directly. Static method {@link #hasParentOrChildQuery} should be used instead.
+     * @param queryBuilder is a queryBuilder object which is accepeted by the visitor.
+     */
+    @Override
+    public void accept(QueryBuilder queryBuilder) {
+        if (queryBuilder instanceof HasParentQueryBuilder || queryBuilder instanceof HasChildQueryBuilder) {
+            queryPresent = true;
+        }
+    }
+
+    @Override
+    public QueryBuilderVisitor getChildVisitor(BooleanClause.Occur occur) {
+        return this;
+    }
+
+    public boolean hasParentOrChildQuery() {
+        return queryPresent;
+    }
+}

--- a/src/test/java/org/opensearch/security/ssl/SSLTest.java
+++ b/src/test/java/org/opensearch/security/ssl/SSLTest.java
@@ -50,6 +50,7 @@ import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.node.Node;
 import org.opensearch.node.PluginAwareNode;
 import org.opensearch.security.OpenSearchSecurityPlugin;
+import org.opensearch.security.ssl.config.CertType;
 import org.opensearch.security.ssl.util.ExceptionUtils;
 import org.opensearch.security.ssl.util.SSLConfigConstants;
 import org.opensearch.security.support.ConfigConstants;
@@ -795,7 +796,7 @@ public class SSLTest extends SingleClusterTest {
         serverContext.init(null, null, null);
         final SSLEngine engine = serverContext.createSSLEngine();
         final List<String> jdkSupportedCiphers = new ArrayList<>(Arrays.asList(engine.getSupportedCipherSuites()));
-        jdkSupportedCiphers.retainAll(SSLConfigConstants.getSecureSSLCiphers(Settings.EMPTY, false));
+        jdkSupportedCiphers.retainAll(SSLConfigConstants.getSecureSSLCiphers(Settings.EMPTY, CertType.TRANSPORT));
         engine.setEnabledCipherSuites(jdkSupportedCiphers.toArray(new String[0]));
 
         final List<String> jdkEnabledCiphers = Arrays.asList(engine.getEnabledCipherSuites());
@@ -807,11 +808,11 @@ public class SSLTest extends SingleClusterTest {
 
     @Test
     public void testUnmodifieableCipherProtocolConfig() throws Exception {
-        SSLConfigConstants.getSecureSSLProtocols(Settings.EMPTY, false)[0] = "bogus";
-        assertThat(SSLConfigConstants.getSecureSSLProtocols(Settings.EMPTY, false)[0], is("TLSv1.3"));
+        SSLConfigConstants.getSecureSSLProtocols(Settings.EMPTY, CertType.TRANSPORT)[0] = "bogus";
+        assertThat(SSLConfigConstants.getSecureSSLProtocols(Settings.EMPTY, CertType.TRANSPORT)[0], is("TLSv1.3"));
 
         try {
-            SSLConfigConstants.getSecureSSLCiphers(Settings.EMPTY, false).set(0, "bogus");
+            SSLConfigConstants.getSecureSSLCiphers(Settings.EMPTY, CertType.TRANSPORT).set(0, "bogus");
             Assert.fail();
         } catch (UnsupportedOperationException e) {
             // expected

--- a/src/test/java/org/opensearch/security/ssl/SslContextHandlerTest.java
+++ b/src/test/java/org/opensearch/security/ssl/SslContextHandlerTest.java
@@ -29,6 +29,7 @@ import org.bouncycastle.asn1.x509.GeneralName;
 import org.bouncycastle.cert.X509CertificateHolder;
 
 import org.opensearch.common.settings.Settings;
+import org.opensearch.security.ssl.config.CertType;
 import org.opensearch.security.ssl.config.KeyStoreConfiguration;
 import org.opensearch.security.ssl.config.SslParameters;
 import org.opensearch.security.ssl.config.TrustStoreConfiguration;
@@ -295,7 +296,7 @@ public class SslContextHandlerTest {
     // CS-ENFORCE-SINGLE
 
     SslContextHandler sslContextHandler() {
-        final var sslParameters = SslParameters.loader(Settings.EMPTY).load(false);
+        final var sslParameters = SslParameters.loader(CertType.TRANSPORT, Settings.EMPTY).load();
         final var trustStoreConfiguration = new TrustStoreConfiguration.PemTrustStoreConfiguration(caCertificatePath);
         final var keyStoreConfiguration = new KeyStoreConfiguration.PemKeyStoreConfiguration(
             accessCertificatePath,

--- a/src/test/java/org/opensearch/security/ssl/config/SslParametersTest.java
+++ b/src/test/java/org/opensearch/security/ssl/config/SslParametersTest.java
@@ -11,14 +11,17 @@
 
 package org.opensearch.security.ssl.config;
 
+import java.security.NoSuchAlgorithmException;
 import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.net.ssl.SSLContext;
 
+import org.junit.Before;
 import org.junit.Test;
 
+import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.common.settings.Settings;
 
 import io.netty.handler.ssl.ClientAuth;
@@ -27,64 +30,162 @@ import io.netty.handler.ssl.SslProvider;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.ALLOWED_SSL_CIPHERS;
+import static org.opensearch.security.ssl.util.SSLConfigConstants.CLIENT_AUTH_MODE;
+import static org.opensearch.security.ssl.util.SSLConfigConstants.ENABLED_CIPHERS;
+import static org.opensearch.security.ssl.util.SSLConfigConstants.ENABLED_PROTOCOLS;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_HTTP_CLIENTAUTH_MODE;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_HTTP_ENABLED_CIPHERS;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_HTTP_ENABLED_PROTOCOLS;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_TRANSPORT_ENABLED_CIPHERS;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_TRANSPORT_ENABLED_PROTOCOLS;
-import static org.opensearch.security.ssl.util.SSLConfigConstants.SSL_HTTP_PREFIX;
-import static org.opensearch.security.ssl.util.SSLConfigConstants.SSL_TRANSPORT_PREFIX;
+import static org.opensearch.security.ssl.util.SSLConfigConstants.SSL_AUX_PREFIX;
+import static org.junit.Assert.assertThrows;
 
 public class SslParametersTest {
 
-    @Test
-    public void testDefaultSslParameters() throws Exception {
-        final var settings = Settings.EMPTY;
-        final var httpSslParameters = SslParameters.loader(settings).load(true);
-        final var transportSslParameters = SslParameters.loader(settings).load(false);
+    private List<String> finalDefaultCiphers;
 
+    private static final String MOCK_AUX_PREFIX_FOO = SSL_AUX_PREFIX + "foo.";
+    private static final String MOCK_AUX_PREFIX_BAR = SSL_AUX_PREFIX + "bar.";
+    private static final CertType MOCK_AUX_CERT_TYPE_FOO = new CertType(MOCK_AUX_PREFIX_FOO);
+    private static final CertType MOCK_AUX_CERT_TYPE_BAR = new CertType(MOCK_AUX_PREFIX_BAR);
+
+    @Before
+    public void setup() throws NoSuchAlgorithmException {
         final var defaultCiphers = List.of(ALLOWED_SSL_CIPHERS);
-        final var finalDefaultCiphers = Stream.of(SSLContext.getDefault().getDefaultSSLParameters().getCipherSuites())
+        finalDefaultCiphers = Stream.of(SSLContext.getDefault().getDefaultSSLParameters().getCipherSuites())
             .filter(defaultCiphers::contains)
             .sorted(String::compareTo)
             .collect(Collectors.toList());
+    }
 
+    @Test
+    public void testDefaultSslParametersForHttp() {
+        final var httpSslParameters = SslParameters.loader(CertType.HTTP, Settings.EMPTY).load();
         assertThat(httpSslParameters.provider(), is(SslProvider.JDK));
-        assertThat(transportSslParameters.provider(), is(SslProvider.JDK));
-
         assertThat(httpSslParameters.allowedProtocols(), is(List.of("TLSv1.3", "TLSv1.2")));
         assertThat(httpSslParameters.allowedCiphers(), is(finalDefaultCiphers));
+        assertThat(httpSslParameters.clientAuth(), is(ClientAuth.OPTIONAL));
+    }
 
+    @Test
+    public void testDefaultSslParametersForAux() {
+        final var auxSslParameters = SslParameters.loader(MOCK_AUX_CERT_TYPE_FOO, Settings.EMPTY).load();
+        assertThat(auxSslParameters.provider(), is(SslProvider.JDK));
+        assertThat(auxSslParameters.allowedProtocols(), is(List.of("TLSv1.3", "TLSv1.2")));
+        assertThat(auxSslParameters.allowedCiphers(), is(finalDefaultCiphers));
+        assertThat(auxSslParameters.clientAuth(), is(ClientAuth.OPTIONAL));
+    }
+
+    @Test
+    public void testDefaultSslParametersForTransport() {
+        final var transportSslParameters = SslParameters.loader(CertType.TRANSPORT, Settings.EMPTY).load();
+        assertThat(transportSslParameters.provider(), is(SslProvider.JDK));
         assertThat(transportSslParameters.allowedProtocols(), is(List.of("TLSv1.3", "TLSv1.2")));
         assertThat(transportSslParameters.allowedCiphers(), is(finalDefaultCiphers));
-
-        assertThat(httpSslParameters.clientAuth(), is(ClientAuth.OPTIONAL));
         assertThat(transportSslParameters.clientAuth(), is(ClientAuth.REQUIRE));
     }
 
     @Test
-    public void testCustomSSlParameters() {
+    public void testCustomSSlParametersForHttp() {
+        final Settings settings = Settings.builder()
+            .put(SECURITY_SSL_HTTP_CLIENTAUTH_MODE, ClientAuth.REQUIRE.name().toLowerCase(Locale.ROOT))
+            .putList(SECURITY_SSL_HTTP_ENABLED_PROTOCOLS, List.of("TLSv1.2", "TLSv1"))
+            .putList(SECURITY_SSL_HTTP_ENABLED_CIPHERS, List.of("TLS_AES_256_GCM_SHA384"))
+            .build();
+        final SslParameters httpSslParameters = SslParameters.loader(CertType.HTTP, settings).load();
+        assertThat(httpSslParameters.provider(), is(SslProvider.JDK));
+        assertThat(httpSslParameters.allowedProtocols(), is(List.of("TLSv1.2")));
+        assertThat(httpSslParameters.allowedCiphers(), is(List.of("TLS_AES_256_GCM_SHA384")));
+        assertThat(httpSslParameters.clientAuth(), is(ClientAuth.REQUIRE));
+    }
+
+    @Test
+    public void testCustomSSlParametersForAux() {
+        final Settings settings = Settings.builder()
+            .put(MOCK_AUX_CERT_TYPE_FOO.sslSettingPrefix() + CLIENT_AUTH_MODE, ClientAuth.REQUIRE.name().toLowerCase(Locale.ROOT))
+            .putList(MOCK_AUX_CERT_TYPE_FOO.sslSettingPrefix() + ENABLED_PROTOCOLS, List.of("TLSv1.2", "TLSv1"))
+            .putList(MOCK_AUX_CERT_TYPE_FOO.sslSettingPrefix() + ENABLED_CIPHERS, List.of("TLS_AES_256_GCM_SHA384"))
+            .build();
+        final SslParameters auxSslParameters = SslParameters.loader(MOCK_AUX_CERT_TYPE_FOO, settings).load();
+        assertThat(auxSslParameters.provider(), is(SslProvider.JDK));
+        assertThat(auxSslParameters.allowedProtocols(), is(List.of("TLSv1.2")));
+        assertThat(auxSslParameters.allowedCiphers(), is(List.of("TLS_AES_256_GCM_SHA384")));
+        assertThat(auxSslParameters.clientAuth(), is(ClientAuth.REQUIRE));
+    }
+
+    @Test
+    public void testCustomSSlParametersForMultiAux() {
+        final Settings settings = Settings.builder()
+            .put(MOCK_AUX_CERT_TYPE_FOO.sslSettingPrefix() + CLIENT_AUTH_MODE, ClientAuth.REQUIRE.name().toLowerCase(Locale.ROOT))
+            .putList(MOCK_AUX_CERT_TYPE_FOO.sslSettingPrefix() + ENABLED_PROTOCOLS, List.of("TLSv1.2", "TLSv1"))
+            .putList(MOCK_AUX_CERT_TYPE_FOO.sslSettingPrefix() + ENABLED_CIPHERS, List.of("TLS_AES_256_GCM_SHA384"))
+            .put(MOCK_AUX_CERT_TYPE_BAR.sslSettingPrefix() + CLIENT_AUTH_MODE, ClientAuth.REQUIRE.name().toLowerCase(Locale.ROOT))
+            .putList(MOCK_AUX_CERT_TYPE_BAR.sslSettingPrefix() + ENABLED_PROTOCOLS, List.of("TLSv1.3"))
+            .putList(MOCK_AUX_CERT_TYPE_BAR.sslSettingPrefix() + ENABLED_CIPHERS, List.of("TLS_AES_128_GCM_SHA256", "DNE"))
+            .build();
+        final SslParameters fooSslParameters = SslParameters.loader(MOCK_AUX_CERT_TYPE_FOO, settings).load();
+        assertThat(fooSslParameters.provider(), is(SslProvider.JDK));
+        assertThat(fooSslParameters.allowedProtocols(), is(List.of("TLSv1.2")));
+        assertThat(fooSslParameters.allowedCiphers(), is(List.of("TLS_AES_256_GCM_SHA384")));
+        assertThat(fooSslParameters.clientAuth(), is(ClientAuth.REQUIRE));
+        final SslParameters barSslParameters = SslParameters.loader(MOCK_AUX_CERT_TYPE_BAR, settings).load();
+        assertThat(barSslParameters.provider(), is(SslProvider.JDK));
+        assertThat(barSslParameters.allowedProtocols(), is(List.of("TLSv1.3")));
+        assertThat(barSslParameters.allowedCiphers(), is(List.of("TLS_AES_128_GCM_SHA256")));
+        assertThat(barSslParameters.clientAuth(), is(ClientAuth.REQUIRE));
+    }
+
+    @Test
+    public void testSSlParametersEmptyProtocolsFails() {
+        final Settings settings = Settings.builder()
+            .put(MOCK_AUX_CERT_TYPE_BAR.sslSettingPrefix() + CLIENT_AUTH_MODE, ClientAuth.REQUIRE.name().toLowerCase(Locale.ROOT))
+            .putList(MOCK_AUX_CERT_TYPE_BAR.sslSettingPrefix() + ENABLED_PROTOCOLS, List.of("TLSv1"))
+            .putList(MOCK_AUX_CERT_TYPE_BAR.sslSettingPrefix() + ENABLED_CIPHERS, List.of("TLS_AES_256_GCM_SHA384"))
+            .build();
+        // Intersection of enabled protocols and allowed protocols is empty list.
+        assertThrows(OpenSearchSecurityException.class, () -> SslParameters.loader(MOCK_AUX_CERT_TYPE_BAR, settings).load());
+    }
+
+    @Test
+    public void testCustomSSlParametersForTransport() {
+        final Settings settings = Settings.builder()
+            .putList(SECURITY_SSL_TRANSPORT_ENABLED_PROTOCOLS, List.of("TLSv1.3", "TLSv1.2"))
+            .putList(SECURITY_SSL_TRANSPORT_ENABLED_CIPHERS, List.of("TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384"))
+            .build();
+        final SslParameters transportSslParameters = SslParameters.loader(CertType.TRANSPORT, settings).load();
+        assertThat(transportSslParameters.provider(), is(SslProvider.JDK));
+        assertThat(transportSslParameters.allowedProtocols(), is(List.of("TLSv1.3", "TLSv1.2")));
+        assertThat(transportSslParameters.allowedCiphers(), is(List.of("TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384")));
+        assertThat(transportSslParameters.clientAuth(), is(ClientAuth.REQUIRE));
+    }
+
+    @Test
+    public void testCustomSSlParametersForHttpAndAuxAndTransport() {
         final var settings = Settings.builder()
             .put(SECURITY_SSL_HTTP_CLIENTAUTH_MODE, ClientAuth.REQUIRE.name().toLowerCase(Locale.ROOT))
             .putList(SECURITY_SSL_HTTP_ENABLED_PROTOCOLS, List.of("TLSv1.2", "TLSv1"))
             .putList(SECURITY_SSL_HTTP_ENABLED_CIPHERS, List.of("TLS_AES_256_GCM_SHA384"))
+            .put(MOCK_AUX_CERT_TYPE_BAR.sslSettingPrefix() + CLIENT_AUTH_MODE, ClientAuth.REQUIRE.name().toLowerCase(Locale.ROOT))
+            .putList(MOCK_AUX_CERT_TYPE_BAR.sslSettingPrefix() + ENABLED_PROTOCOLS, List.of("TLSv1.2", "TLSv1"))
+            .putList(MOCK_AUX_CERT_TYPE_BAR.sslSettingPrefix() + ENABLED_CIPHERS, List.of("TLS_AES_256_GCM_SHA384"))
             .putList(SECURITY_SSL_TRANSPORT_ENABLED_PROTOCOLS, List.of("TLSv1.3", "TLSv1.2"))
             .putList(SECURITY_SSL_TRANSPORT_ENABLED_CIPHERS, List.of("TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384"))
             .build();
-        final var httpSslParameters = SslParameters.loader(settings.getByPrefix(SSL_HTTP_PREFIX)).load(true);
-        final var transportSslParameters = SslParameters.loader(settings.getByPrefix(SSL_TRANSPORT_PREFIX)).load(false);
-
+        final SslParameters httpSslParameters = SslParameters.loader(CertType.HTTP, settings).load();
+        final SslParameters auxSslParameters = SslParameters.loader(MOCK_AUX_CERT_TYPE_BAR, settings).load();
+        final SslParameters transportSslParameters = SslParameters.loader(CertType.TRANSPORT, settings).load();
         assertThat(httpSslParameters.provider(), is(SslProvider.JDK));
-        assertThat(transportSslParameters.provider(), is(SslProvider.JDK));
-
         assertThat(httpSslParameters.allowedProtocols(), is(List.of("TLSv1.2")));
         assertThat(httpSslParameters.allowedCiphers(), is(List.of("TLS_AES_256_GCM_SHA384")));
-
+        assertThat(httpSslParameters.clientAuth(), is(ClientAuth.REQUIRE));
+        assertThat(auxSslParameters.provider(), is(SslProvider.JDK));
+        assertThat(auxSslParameters.allowedProtocols(), is(List.of("TLSv1.2")));
+        assertThat(auxSslParameters.allowedCiphers(), is(List.of("TLS_AES_256_GCM_SHA384")));
+        assertThat(auxSslParameters.clientAuth(), is(ClientAuth.REQUIRE));
+        assertThat(transportSslParameters.provider(), is(SslProvider.JDK));
         assertThat(transportSslParameters.allowedProtocols(), is(List.of("TLSv1.3", "TLSv1.2")));
         assertThat(transportSslParameters.allowedCiphers(), is(List.of("TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384")));
-
-        assertThat(httpSslParameters.clientAuth(), is(ClientAuth.REQUIRE));
         assertThat(transportSslParameters.clientAuth(), is(ClientAuth.REQUIRE));
     }
-
 }

--- a/src/test/java/org/opensearch/security/ssl/transport/SPIFFEPrincipalExtractorTest.java
+++ b/src/test/java/org/opensearch/security/ssl/transport/SPIFFEPrincipalExtractorTest.java
@@ -1,0 +1,122 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.ssl.transport;
+
+import java.security.cert.CertificateParsingException;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SPIFFEPrincipalExtractorTest {
+
+    @Test
+    public void testExtractSpiffePrincipal() throws Exception {
+        X509Certificate cert = mock(X509Certificate.class);
+        List<List<?>> sanList = new ArrayList<>();
+        sanList.add(Arrays.asList(0, "otherName"));
+        sanList.add(Arrays.asList(1, "rfc822Name"));
+        sanList.add(Arrays.asList(2, "DNSName"));
+        sanList.add(Arrays.asList(3, "x400Address"));
+        sanList.add(Arrays.asList(4, "directoryName"));
+        sanList.add(Arrays.asList(5, "ediPartyName"));
+        sanList.add(Arrays.asList(6, "spiffe://example.org/test")); // uniformResourceIdentifier
+        sanList.add(Arrays.asList(7, "IPAddress"));
+        sanList.add(Arrays.asList(8, "registeredID"));
+        when(cert.getSubjectAlternativeNames()).thenReturn(sanList);
+
+        SPIFFEPrincipalExtractor extractor = new SPIFFEPrincipalExtractor();
+        String principal = extractor.extractPrincipal(cert, PrincipalExtractor.Type.TRANSPORT);
+
+        assertEquals("CN=spiffe://example.org/test", principal);
+    }
+
+    @Test
+    public void testExtractPrincipal_noSpiffeUri() throws Exception {
+        X509Certificate cert = mock(X509Certificate.class);
+        List<List<?>> sanList = new ArrayList<>();
+        sanList.add(Arrays.asList(6, "not-spiffe://example.org/test"));
+        when(cert.getSubjectAlternativeNames()).thenReturn(sanList);
+
+        SPIFFEPrincipalExtractor extractor = new SPIFFEPrincipalExtractor();
+        String principal = extractor.extractPrincipal(cert, PrincipalExtractor.Type.TRANSPORT);
+
+        assertNull(principal);
+    }
+
+    @Test
+    public void testExtractPrincipal_nullCertificate() {
+        SPIFFEPrincipalExtractor extractor = new SPIFFEPrincipalExtractor();
+        assertNull(extractor.extractPrincipal(null, PrincipalExtractor.Type.TRANSPORT));
+    }
+
+    @Test
+    public void testExtractPrincipal_nullSAN() throws Exception {
+        X509Certificate cert = mock(X509Certificate.class);
+        when(cert.getSubjectAlternativeNames()).thenReturn(null);
+
+        SPIFFEPrincipalExtractor extractor = new SPIFFEPrincipalExtractor();
+        String principal = extractor.extractPrincipal(cert, PrincipalExtractor.Type.TRANSPORT);
+
+        assertNull(principal);
+    }
+
+    @Test
+    public void testExtractPrincipal_certificateParsingException() throws Exception {
+        X509Certificate cert = mock(X509Certificate.class);
+        when(cert.getSubjectAlternativeNames()).thenThrow(new CertificateParsingException("bad"));
+
+        SPIFFEPrincipalExtractor extractor = new SPIFFEPrincipalExtractor();
+        String principal = extractor.extractPrincipal(cert, PrincipalExtractor.Type.TRANSPORT);
+
+        assertNull(principal);
+    }
+
+    @Test
+    public void testExtractPrincipal_sanItemNullAndTooShort() throws Exception {
+        X509Certificate cert = mock(X509Certificate.class);
+
+        List<List<?>> sanList = new ArrayList<>();
+        sanList.add(null); // hits sanItem == null
+        sanList.add(Arrays.asList(6)); // size < 2
+
+        when(cert.getSubjectAlternativeNames()).thenReturn(sanList);
+
+        SPIFFEPrincipalExtractor extractor = new SPIFFEPrincipalExtractor();
+        String principal = extractor.extractPrincipal(cert, PrincipalExtractor.Type.TRANSPORT);
+
+        assertNull(principal);
+    }
+
+    @Test
+    public void testExtractPrincipal_altNameTypeNotIntegerOrValueNotString() throws Exception {
+        X509Certificate cert = mock(X509Certificate.class);
+        List<List<?>> sanList = new ArrayList<>();
+        // altNameType is null
+        sanList.add(Arrays.asList(null, "spiffe://example.org/test"));
+        // altNameValue not a string
+        sanList.add(Arrays.asList(6, 12345));
+        when(cert.getSubjectAlternativeNames()).thenReturn(sanList);
+
+        SPIFFEPrincipalExtractor extractor = new SPIFFEPrincipalExtractor();
+        String principal = extractor.extractPrincipal(cert, PrincipalExtractor.Type.TRANSPORT);
+
+        assertNull(principal);
+    }
+}

--- a/src/test/java/org/opensearch/security/ssl/util/SSLConfigConstantsTest.java
+++ b/src/test/java/org/opensearch/security/ssl/util/SSLConfigConstantsTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 import org.junit.Test;
 
 import org.opensearch.common.settings.Settings;
+import org.opensearch.security.ssl.config.CertType;
 
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_HTTP_ENABLED_PROTOCOLS;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_TRANSPORT_ENABLED_PROTOCOLS;
@@ -24,13 +25,13 @@ public class SSLConfigConstantsTest {
 
     @Test
     public void testDefaultTLSProtocols() {
-        final var tlsDefaultProtocols = SSLConfigConstants.getSecureSSLProtocols(Settings.EMPTY, false);
+        final var tlsDefaultProtocols = SSLConfigConstants.getSecureSSLProtocols(Settings.EMPTY, CertType.TRANSPORT);
         assertArrayEquals(new String[] { "TLSv1.3", "TLSv1.2", "TLSv1.1" }, tlsDefaultProtocols);
     }
 
     @Test
     public void testDefaultSSLProtocols() {
-        final var sslDefaultProtocols = SSLConfigConstants.getSecureSSLProtocols(Settings.EMPTY, true);
+        final var sslDefaultProtocols = SSLConfigConstants.getSecureSSLProtocols(Settings.EMPTY, CertType.HTTP);
         assertArrayEquals(new String[] { "TLSv1.3", "TLSv1.2", "TLSv1.1" }, sslDefaultProtocols);
     }
 
@@ -38,7 +39,7 @@ public class SSLConfigConstantsTest {
     public void testCustomTLSProtocols() {
         final var tlsDefaultProtocols = SSLConfigConstants.getSecureSSLProtocols(
             Settings.builder().putList(SECURITY_SSL_TRANSPORT_ENABLED_PROTOCOLS, List.of("TLSv1", "TLSv1.1")).build(),
-            false
+            CertType.TRANSPORT
         );
         assertArrayEquals(new String[] { "TLSv1", "TLSv1.1" }, tlsDefaultProtocols);
     }
@@ -47,7 +48,7 @@ public class SSLConfigConstantsTest {
     public void testCustomSSLProtocols() {
         final var sslDefaultProtocols = SSLConfigConstants.getSecureSSLProtocols(
             Settings.builder().putList(SECURITY_SSL_HTTP_ENABLED_PROTOCOLS, List.of("TLSv1", "TLSv1.1")).build(),
-            true
+            CertType.HTTP
         );
         assertArrayEquals(new String[] { "TLSv1", "TLSv1.1" }, sslDefaultProtocols);
     }

--- a/src/test/java/org/opensearch/security/util/ParentChildrenQueryDetectorTest.java
+++ b/src/test/java/org/opensearch/security/util/ParentChildrenQueryDetectorTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+package org.opensearch.security.util;
+
+import org.apache.lucene.search.join.ScoreMode;
+import org.junit.Test;
+
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.index.query.TermQueryBuilder;
+import org.opensearch.join.query.HasChildQueryBuilder;
+import org.opensearch.join.query.HasParentQueryBuilder;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class ParentChildrenQueryDetectorTest {
+
+    @Test
+    public void termQueryShouldNotBeParentChildQuery() {
+        TermQueryBuilder query = QueryBuilders.termQuery("field", "value");
+
+        assertThat(ParentChildrenQueryDetector.hasParentOrChildQuery(query), equalTo(false));
+    }
+
+    @Test
+    public void topLevelHasParentQueryShouldBeDetected() {
+        HasParentQueryBuilder query = new HasParentQueryBuilder("my_type", QueryBuilders.termQuery("field", "value"), false);
+
+        assertThat(ParentChildrenQueryDetector.hasParentOrChildQuery(query), equalTo(true));
+    }
+
+    @Test
+    public void topLevelHasChildQueryShouldBeDetected() {
+        HasChildQueryBuilder query = new HasChildQueryBuilder("my_type", QueryBuilders.termQuery("field", "value"), ScoreMode.None);
+
+        assertThat(ParentChildrenQueryDetector.hasParentOrChildQuery(query), equalTo(true));
+    }
+
+    @Test
+    public void shouldDetectHasParentQueryInsideBooleanQuery() {
+        BoolQueryBuilder query = QueryBuilders.boolQuery() //
+            .must(new HasParentQueryBuilder("my_type", QueryBuilders.termQuery("field", "value"), false)) //
+            .should(QueryBuilders.termQuery("another_field", "another_value"));
+
+        assertThat(ParentChildrenQueryDetector.hasParentOrChildQuery(query), equalTo(true));
+
+    }
+
+}


### PR DESCRIPTION
### Description
* Category: Feature

* Why these changes are required?

As an OpenSearch cluster operator, I want to be able to use existing SPIFFE X509-SVID workload identities for node and admin authentication, so that I do not have to setup dedicated workload PKI infrastructure for OpenSearch.

* What is the old behavior before changes and new behavior after changes?

Default behavior is unchanged, this adds an additional implementation of the `PrincipalExtractor` class that may be utilized via the existing `plugins.security.ssl.transport.principal_extractor_class` configuration parameter.

### Testing
This has been manually tested in a running cluster over a period of two weeks, including node transport and admin authentication. Unit and integration tests are in-progress and will be completed before opening a PR to the main `opensearch-project/security` repository.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
