### PR TITLE
[Backport:2.19] Add SPIFFEPrincipalExtractor

### DIFF
--- a/src/main/java/org/opensearch/security/ssl/transport/SPIFFEPrincipalExtractor.java
+++ b/src/main/java/org/opensearch/security/ssl/transport/SPIFFEPrincipalExtractor.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2015-2017 floragunn GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.opensearch.security.ssl.transport;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.security.cert.CertificateParsingException;
+import java.security.cert.X509Certificate;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import org.opensearch.SpecialPermission;
+
+public class SPIFFEPrincipalExtractor implements PrincipalExtractor {
+
+    protected final Logger log = LogManager.getLogger(this.getClass());
+
+    @Override
+    @SuppressWarnings("removal")
+    public String extractPrincipal(final X509Certificate x509Certificate, final Type type) {
+        if (x509Certificate == null) {
+            return null;
+        }
+
+        final SecurityManager sm = System.getSecurityManager();
+
+        if (sm != null) {
+            sm.checkPermission(new SpecialPermission());
+        }
+
+        final Collection<List<?>> altNames = AccessController.doPrivileged(new PrivilegedAction<Collection<List<?>>>() {
+            @Override
+            public Collection<List<?>> run() {
+                try {
+                    return x509Certificate.getSubjectAlternativeNames();
+                } catch (CertificateParsingException e) {
+                    log.error("Unable to parse X509 altNames", e);
+                    return null;
+                }
+            }
+        });
+
+        if (altNames == null) {
+            return null;
+        }
+
+        for (List<?> sanItem : altNames) {
+            if (sanItem == null || sanItem.size() < 2) {
+                continue;
+            }
+            Integer altNameType = (Integer) sanItem.get(0);
+            Object altNameValue = sanItem.get(1);
+            if (altNameType != null && altNameType == 6 && altNameValue instanceof String) {
+                String uriValue = (String) altNameValue;
+                if (uriValue.startsWith("spiffe://")) {
+                    if (log.isTraceEnabled()) {
+                        log.trace("principal: CN={}", uriValue);
+                    }
+                    return String.format("CN=%s", uriValue);
+                }
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
### Description
* Category: Feature

* Why these changes are required?

As an OpenSearch cluster operator, I want to be able to use existing SPIFFE X509-SVID workload identities for node and admin authentication, so that I do not have to setup dedicated workload PKI infrastructure for OpenSearch.

* What is the old behavior before changes and new behavior after changes?

Default behavior is unchanged, this adds an additional implementation of the `PrincipalExtractor` class that may be utilized via the existing `plugins.security.ssl.transport.principal_extractor_class` configuration parameter.

### Testing
This has been manually tested in a running cluster over a period of two weeks, including node transport and admin authentication. Unit and integration tests are in-progress and will be completed before opening a PR to the main `opensearch-project/security` repository.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
